### PR TITLE
Fixed incorrect order of storing manifest entries

### DIFF
--- a/javatools/manifest.py
+++ b/javatools/manifest.py
@@ -263,7 +263,7 @@ class Manifest(ManifestSection):
         """
 
         ManifestSection.store(self, stream)
-        for _name, sect in sorted(self.sub_sections.items()):
+        for sect in sorted(self.sub_sections.values()):
             sect.store(stream)
 
 


### PR DESCRIPTION
Initial code did not actually sort the manifest sections which are outputted. Check with:

```
$ touch a b
$ jar cf test.jar b a   # Note the order of arguments, b goes first
$ manifest -c test.jar
Manifest-Version: 1.0

Name: b
MD5-Digest: dcje2pRsfN6UtLyl4AFmFw==
SHA1-Digest: tmZ2kcNfEY7tfoFOZaOJMjI/cBU=

Name: a
MD5-Digest: 1B2M2Y8AsgTpgAmY7PhCfg==
SHA1-Digest: 2jmj7l5rSw0yVb/vlWAYkK/YBwk=
```

Entries in the result are not sorted. This patch fixes it.
