### PR TITLE
When manifest is loaded from a file, newline separator is read and stored

### DIFF
--- a/tests/data/manifest.dos-newlines.mf
+++ b/tests/data/manifest.dos-newlines.mf
@@ -1,0 +1,6 @@
+Manifest-Version: 1.0
+Created-By: 1.7.0_51 (Oracle Corporation)
+
+Name: file.txt
+SHA-256-Digest: 47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
+

--- a/tests/manifest.py
+++ b/tests/manifest.py
@@ -118,5 +118,8 @@ class ManifestTest(TestCase):
         self.manifest_load_store("manifest.SHA-512.mf")
 
 
+    def test_load_dos_newlines(self):
+        self.manifest_load_store("manifest.dos-newlines.mf")
+
 #
 # The end.


### PR DESCRIPTION
When a manifest is loaded from a file, the newline separator as present in the file is stored in the manifest.
Before, `linesep` was a field of `ManifestSection`. This did not describe the reality well: sections of the same manifest should all have the same line ending. Now, `linesep` is a field of `Manifest`. This also simplified (or, better say, made possible) its correct processing.

A corresponding test added: reading/storing a manifest with DOS line endings.
