### PR TITLE
Cosmetic cleanup

### DIFF
--- a/javatools/manifest.py
+++ b/javatools/manifest.py
@@ -416,7 +416,7 @@ class SignatureManifest(Manifest):
         by Java-style name.
         """
 
-        # pick a line seperator for creating checksums of the manifest
+        # pick a line separator for creating checksums of the manifest
         # contents. We want to use either the one from the given
         # manifest, or the OS default if it hasn't specified one.
         linesep = manifest.linesep or os.linesep
@@ -439,7 +439,7 @@ class SignatureManifest(Manifest):
         for sub_section in manifest.sub_sections.values():
             sub_data = sub_section.get_data(linesep)
 
-            # create a checksums of the section body and store it as a
+            # create the checksum of the section body and store it as a
             # sub-section of our own
             h_section = digest()
             h_section.update(sub_data)
@@ -832,7 +832,7 @@ def cli_sign(options, rest):
     mf = Manifest()
     mf.parse(jar_file.read("META-INF/MANIFEST.MF"))
 
-    # create a signature manifest, and make it match the line seperator
+    # create a signature manifest, and make it match the line separator
     # style of the manifest it'll be digesting.
     sf = SignatureManifest(linesep=mf.linesep)
     sf.digest_manifest(mf, "SHA-256")

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -35,9 +35,7 @@ def get_data_fn(which):
 
 
 def get_class_fn(which):
-    which = "data/%s.class" % which
-    fn = pkg_resources.resource_filename(__name__, which)
-    return fn
+    return get_data_fn(which + ".class")
 
 
 def load(which):

--- a/tests/manifest.py
+++ b/tests/manifest.py
@@ -24,7 +24,6 @@ license: LGPL v.3
 from . import get_data_fn
 from javatools.manifest import main, Manifest
 
-from cStringIO import StringIO
 from unittest import TestCase
 from tempfile import mkstemp
 
@@ -94,7 +93,7 @@ class ManifestTest(TestCase):
         return mf
 
 
-    def test_create_sha256(self):
+    def test_create_sha1(self):
         self.manifest_cli_create("-d SHA1", "manifest.SHA1.mf")
 
 


### PR DESCRIPTION
- some spelling fixes
- unused import removed
- test_create_sha256() renamed to test_create_sha1() accordingly to what it does
- minor redundancy removed by call to get_data_fn()
