### PR TITLE
Fixed syntax error

### DIFF
--- a/javatools/manifest.py
+++ b/javatools/manifest.py
@@ -843,7 +843,7 @@ def cli_sign(options, rest):
 
 def cli(options, rest):
 
-    elif options.create:
+    if options.create:
         return cli_create(options, rest)
 
     elif options.query:


### PR DESCRIPTION
I shall compare `pylint` results of my pull request against the current master - but the current master has a syntax error which prevents reporting. So pushing this micro fix.
