### PR TITLE
Implemented the 'second chance' for verification of the signature file

### DIFF
--- a/tests/data/sf-no-whole-digest.mf
+++ b/tests/data/sf-no-whole-digest.mf
@@ -1,0 +1,6 @@
+Manifest-Version: 1.0
+Created-By: 1.7.0_51 (Oracle Corporation)
+
+Name: a
+SHA-256-Digest: 47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
+

--- a/tests/data/sf-no-whole-digest.sf
+++ b/tests/data/sf-no-whole-digest.sf
@@ -1,0 +1,8 @@
+Signature-Version: 1.0
+SHA-256-Digest-Manifest-Main-Attributes: AQtYHrY4BNvf1XaaJWea5rSY9Ew41
+ jydwG8dXidfcqw=
+Created-By: python-javatools tester
+
+Name: a
+SHA-256-Digest: mig7TbtfO91Bsd7kLoCfURurltzOXNHG8JKjhBSR/Y0=
+

--- a/tests/manifest.py
+++ b/tests/manifest.py
@@ -22,7 +22,7 @@ license: LGPL v.3
 
 
 from . import get_data_fn
-from javatools.manifest import main, Manifest, verify
+from javatools.manifest import main, Manifest, SignatureManifest, verify
 
 from os import unlink
 from shutil import copyfile
@@ -158,5 +158,16 @@ class ManifestTest(TestCase):
 
         unlink(tmp_jar)
 
+    def test_verify_mf_checksums_no_whole_digest(self):
+        sf_file = "sf-no-whole-digest.sf"
+        mf_file = "sf-no-whole-digest.mf"
+        sf = SignatureManifest()
+        sf.parse_file(get_data_fn(sf_file))
+        mf = Manifest()
+        mf.parse_file(get_data_fn(mf_file))
+        error_message = sf.verify_manifest_checksums(mf)
+        self.assertIsNone(error_message,
+            "Verification of signature file %s against manifest %s failed: %s"
+            % (sf_file, mf_file, error_message))
 #
 # The end.


### PR DESCRIPTION
Done one TODO: JAR signature file specification allows for the signature over whole manifest to mismatch. (Presumably because new files could be added to JAR, which changed the manifest.) Verification still should succeed if the signature over "manifest main attributes" and the signature over every manifest entry matches. This second check is implemented.
