### PR TITLE
Bug when reading manifest from Jar

### DIFF
--- a/javatools/jarinfo.py
+++ b/javatools/jarinfo.py
@@ -162,7 +162,7 @@ class JarInfo(object):
 
         mf = Manifest()
         with self.open(mf_entry) as data:
-            mf.parse(data)
+            mf.parse(data.read())
         return mf
 
 


### PR DESCRIPTION
An UnsupportedOperation exception is thrown when `get_manifest` is called on a
JarInfo object.

This exception occurs because `get_manifest` passes a zipfile.ZipExtFile object
to the parse method of the Manifest class. The ZipExtFile class does not
support `tell` and `seek` operations, and therefore throws the UnsupportedOperation
exception.

To fix this, `get_manifest` reads the zipfile.ZipExtFile object and passes a
string to Manifest's `parse` method.
