### PR TITLE
Command-line arguments of jarutil handled (more) properly

### DIFF
--- a/javatools/jarutil.py
+++ b/javatools/jarutil.py
@@ -168,6 +168,11 @@ def cli_verify_jar_signature(argument_list):
     TODO: use trusted keystore;
     """
 
+    usage_message = "Usage: jarutil v file.jar trusted_certificate.pem key_alias"
+    if len(argument_list) != 3:
+        print usage_message
+        return 1
+
     (jar_file, certificate, key_alias) = argument_list
     result_message = verify(certificate, jar_file, key_alias)
     if result_message is not None:

--- a/tests/jarutil.py
+++ b/tests/jarutil.py
@@ -32,8 +32,8 @@ from javatools.jarutil import cli_create_jar, cli_sign_jar, \
 class JarutilTest(TestCase):
 
     def cli_verify_wrap(self, jar, cert, alias):
-            self.assertEqual(0, cli_verify_jar_signature(
-                get_data_fn(jar), get_data_fn(cert), alias),
+            self.assertEqual(0, cli_verify_jar_signature([
+                get_data_fn(jar), get_data_fn(cert), alias]),
                 "cli_verify_jar_signature() failed on %s with certificate %s,"
                 " alias %s" % (jar, cert, alias))
 
@@ -77,7 +77,7 @@ class JarutilTest(TestCase):
         key = get_data_fn("javatools.pem")
         with NamedTemporaryFile() as tmp_jar:
             copyfile(src, tmp_jar.name)
-            cli_sign_jar(None, tmp_jar.name, cert, key, key_alias)
+            cli_sign_jar([tmp_jar.name, cert, key, key_alias])
             error_message = verify(cert, tmp_jar.name, key_alias)
             self.assertIsNone(error_message,
                               "Verification of JAR which we just signed failed: %s"
@@ -90,7 +90,7 @@ class JarutilTest(TestCase):
         key = get_data_fn("ec-key.pem")
         with NamedTemporaryFile() as tmp_jar:
             copyfile(src, tmp_jar.name)
-            cli_sign_jar(None, tmp_jar.name, cert, key, key_alias)
+            cli_sign_jar([tmp_jar.name, cert, key, key_alias])
             error_message = verify(cert, tmp_jar.name, key_alias)
             self.assertIsNone(error_message,
                               "Verification of JAR which we just signed failed: %s"


### PR DESCRIPTION
Jarutil's first mandatory parameter is the command (`s` for "sign", `c` for "create", `v` for "verify). Depending on the command, number of remaining mandatory parameters and set of options varies.

This is reflected now; before, everything was handled as option.

Closes part of #41.
