### PR TITLE
Added correct flags, with which jarsigner recognizes the JAR signatures.

### DIFF
--- a/javatools/crypto.py
+++ b/javatools/crypto.py
@@ -79,7 +79,8 @@ def create_signature_block(openssl_digest, certificate, private_key, data):
 
     smime = SMIME.SMIME()
     smime.load_key_bio(BIO.openfile(private_key), BIO.openfile(certificate))
-    pkcs7 = smime.sign(BIO.MemoryBuffer(data), flags=SMIME.PKCS7_BINARY)
+    pkcs7 = smime.sign(BIO.MemoryBuffer(data),
+                       flags=(SMIME.PKCS7_BINARY | SMIME.PKCS7_DETACHED | SMIME.PKCS7_NOATTR))
     tmp = BIO.MemoryBuffer()
     pkcs7.write_der(tmp)
     return tmp.read()


### PR DESCRIPTION
Without flags `PKCS7_DETACHED` and `PKCS7_NOATTR`, JAR signatures created
by `python-javatools` are not recognized by `jarsigner`. Missing flags added.

This compatibility (signatures created by `python-javatools` being accepted by `jarsigner`) is not tested by any unit test. Is it acceptable/desired to have a test, using external programs?

Closes #46.