### PR TITLE
Added possibility to put the signed jar to another file

### DIFF
--- a/javatools/jarutil.py
+++ b/javatools/jarutil.py
@@ -137,7 +137,7 @@ def verify(certificate, jar_file, key_alias):
 
 
 def sign(jar_file, cert_file, key_file, key_alias,
-         extra_certs=None, digest="SHA-256"):
+         extra_certs=None, digest="SHA-256", output=None):
     """
     Signs the jar (almost) identically to jarsigner.
     :exception ManifestNotFoundError, CannotFindKeyTypeError
@@ -180,7 +180,7 @@ def sign(jar_file, cert_file, key_file, key_alias,
 
         new_jar.close()
         new_jar_file.flush()
-        copyfile(new_jar_file.name, jar_file)
+        copyfile(new_jar_file.name, jar_file if output is None else output)
 
 
 def cli_create_jar(argument_list):
@@ -203,6 +203,9 @@ def cli_sign_jar(argument_list=None):
                       help="Digest algorithm used for signing   ")
     parser.add_option("-c", "--chain", action="append",
                       help="Additional certificates to embed into the signature (PEM format). More than one can be provided.")
+    parser.add_option("-o", "--output",
+                      help="Filename to put signed jar. If not provided, the"
+                      " signature is added to the original jar file.")
     (options, mand_args) = parser.parse_args(argument_list)
 
     if len(mand_args) != 4:
@@ -212,9 +215,10 @@ def cli_sign_jar(argument_list=None):
     (jar_file, cert_file, key_file, key_alias) = mand_args
     digest = options.digest if options and options.digest else "SHA-256"
     extra_certs = options.chain if options and options.chain else None
+    output = options.output if options and options.output else None
 
     try:
-        sign(jar_file, cert_file, key_file, key_alias, extra_certs, digest)
+        sign(jar_file, cert_file, key_file, key_alias, extra_certs, digest, output)
     except CannotFindKeyTypeError:
         print "Cannot determine private key type (is it in PEM format?)"
         return 1

--- a/tests/jarutil.py
+++ b/tests/jarutil.py
@@ -90,6 +90,20 @@ class JarutilTest(TestCase):
                         "Verification of JAR which we just signed failed")
 
 
+    def test_cli_sign_new_file_and_verify(self):
+        src = get_data_fn("cli-sign-and-verify.jar")
+        #dst = get_data_fn("tmp.jar")
+        key_alias = "SAMPLE3"
+        cert = get_data_fn("javatools-cert.pem")
+        key = get_data_fn("javatools.pem")
+        with NamedTemporaryFile() as tmp_jar, NamedTemporaryFile() as dst:
+            copyfile(src, tmp_jar.name)
+            cli_sign_jar([tmp_jar.name, cert, key, key_alias,
+                          "-o", dst.name])
+            self.verify_wrap(cert, dst.name, key_alias,
+                        "Verification of JAR which we just signed failed")
+
+
     def test_cli_sign_and_verify_ecdsa_pkcs8_sha512(self):
         src = get_data_fn("cli-sign-and-verify.jar")
         key_alias = "SAMPLE3"


### PR DESCRIPTION
`jarsigner` has option `-signed-jar` to place the signed jar to another file, not to overwrite the original. Implemented the same.

Closes KonstantinShemyak#11.