### PR TITLE
Minor cleanup: verify_signature_block() takes data instead of file name

### DIFF
--- a/javatools/crypto.py
+++ b/javatools/crypto.py
@@ -112,15 +112,15 @@ def create_signature_block(openssl_digest, certificate, private_key,
     return tmp.read()
 
 
-def verify_signature_block(certificate_file, content_file, signature):
+def verify_signature_block(certificate_file, content, signature):
     """
     Verifies the 'signature' over the 'content', trusting the
     'certificate'.
 
     :param certificate_file: the trusted certificate (PEM format)
     :type certificate_file: str
-    :param content_file: The signature should match this content
-    :type content_file: str
+    :param content: The signature should match this content
+    :type content: str
     :param signature: data (DER format) subject to check
     :type signature: str
     :return None if the signature validates.
@@ -135,7 +135,7 @@ def verify_signature_block(certificate_file, content_file, signature):
     smime = SMIME.SMIME()
     smime.set_x509_stack(signers_cert_stack)
     smime.set_x509_store(trusted_cert_store)
-    data_bio = BIO.openfile(content_file)
+    data_bio = BIO.MemoryBuffer(content)
 
     try:
         smime.verify(pkcs7, data_bio)

--- a/javatools/jarutil.py
+++ b/javatools/jarutil.py
@@ -92,30 +92,26 @@ def verify(certificate, jar_file):
     sf_data = zip_file.read(sf_filename)
 
     # Step 1: check the crypto part.
-    with NamedTemporaryFile('w') as tmp_buf:
-        sf_file = tmp_buf.name
-        tmp_buf.write(sf_data)
-        tmp_buf.flush()
-        file_list = zip_file.namelist()
-        sig_block_filename = None
-        # JAR specification mentions only RSA and DSA; jarsigner also has EC
-        # TODO: what about "SIG-*"?
-        signature_extensions = ("RSA", "DSA", "EC")
-        for extension in signature_extensions:
-            candidate_filename = "META-INF/%s.%s" % (key_alias, extension)
-            if candidate_filename in file_list:
-                sig_block_filename = candidate_filename
-                break
-        if sig_block_filename is None:
-            raise JarSignatureMissingError("None of %s found in JAR" %
-                ", ".join(key_alias + "." + x for x in signature_extensions))
+    file_list = zip_file.namelist()
+    sig_block_filename = None
+    # JAR specification mentions only RSA and DSA; jarsigner also has EC
+    # TODO: what about "SIG-*"?
+    signature_extensions = ("RSA", "DSA", "EC")
+    for extension in signature_extensions:
+        candidate_filename = "META-INF/%s.%s" % (key_alias, extension)
+        if candidate_filename in file_list:
+            sig_block_filename = candidate_filename
+            break
+    if sig_block_filename is None:
+        raise JarSignatureMissingError("None of %s found in JAR" %
+            ", ".join(key_alias + "." + x for x in signature_extensions))
 
-        sig_block_data = zip_file.read(sig_block_filename)
-        try:
-            verify_signature_block(certificate, sf_file, sig_block_data)
-        except SignatureBlockVerificationError, message:
-            raise SignatureBlockFileVerificationError(
-                "Signature block verification failed: %s" % message)
+    sig_block_data = zip_file.read(sig_block_filename)
+    try:
+        verify_signature_block(certificate, sf_data, sig_block_data)
+    except SignatureBlockVerificationError, message:
+        raise SignatureBlockFileVerificationError(
+            "Signature block verification failed: %s" % message)
 
 
     # KEYALIAS.SF is correctly signed.


### PR DESCRIPTION
No functional changes, cleanup only. -4 code lines.
Closes KonstantinShemyak#24.