### PR TITLE
Do not attempt to print binary signature file change data into diffs

### DIFF
--- a/javatools/manifest.py
+++ b/javatools/manifest.py
@@ -658,7 +658,7 @@ class SignatureBlockFileChange(GenericChange):
     label = "Signature Block File"
 
     def get_description(self):
-        return "[binary file change]"
+        return "[binary data change]"
 
     def fn_pretty(self, side_data):
         return "[binary data]"

--- a/javatools/manifest.py
+++ b/javatools/manifest.py
@@ -660,6 +660,9 @@ class SignatureBlockFileChange(GenericChange):
     def get_description(self):
         return "[binary file change]"
 
+    def fn_pretty(self, side_data):
+        return "[binary data]"
+
 
 def b64_encoded_digest(data, algorithm):
     h = algorithm()

--- a/tests/jardiff.py
+++ b/tests/jardiff.py
@@ -60,6 +60,11 @@ class JardiffTest(TestCase):
         self.cli_jardiff_wrap(1, "ec.jar", "ec-sig-mf-tampered.jar",
             "Change in manifest signature file is not detected")
 
+    def test_json_binary_diff(self):
+        left = get_data_fn(os.path.join("test_jardiff", "ec.jar"))
+        right = get_data_fn(os.path.join("test_jardiff", "ec-tampered.jar"))
+        self.assertEqual(1, main(["argv0", "--json", left, right]))
+
     # Options from relevant option groups are accepted:
     def test_options_accepted(self):
         left = get_data_fn(os.path.join("test_jardiff", "ec.jar"))
@@ -76,7 +81,6 @@ class JardiffTest(TestCase):
         self.assertEqual(1, main(["argv0", "--json-indent=4", left, right]))
         # HTML reporting options:
         self.assertEqual(1, main(["argv0", "--html-copy-data=foo", left, right]))
-
 
 
 #


### PR DESCRIPTION
JSON jardiff report attempts to print the difference, decoding it as UTF-8. It chokes on binary data, such as signature block file.

Update the printing method of `SignatureBlockFileChange` to show own difference as fixed string "binary data".

Closes #69.