### PR TITLE
Support for signing JARs with signature algorithms other than SHA-256

### DIFF
--- a/javatools/crypto.py
+++ b/javatools/crypto.py
@@ -79,8 +79,6 @@ def create_signature_block(openssl_digest, certificate, private_key,
 
     :param openssl_digest: alrogithm known to OpenSSL used to digest the data
     :type openssl_digest: str
-    NOTE: not used. M2Crypto cannot pass the signing digest. This is in plans
-          for a future release: https://gitlab.com/m2crypto/m2crypto/issues/151
     :param certificate: filename of the certificate file (PEM format)
     :type certificate: str
     :param private_key:filename of private key used to sign (PEM format)
@@ -104,6 +102,7 @@ def create_signature_block(openssl_digest, certificate, private_key,
         smime.set_x509_stack(stack)
 
     pkcs7 = smime.sign(BIO.MemoryBuffer(data),
+                       algo=openssl_digest,
                        flags=(SMIME.PKCS7_BINARY |
                               SMIME.PKCS7_DETACHED |
                               SMIME.PKCS7_NOATTR))

--- a/javatools/jarutil.py
+++ b/javatools/jarutil.py
@@ -184,7 +184,7 @@ def sign(jar_file, cert_file, key_file, key_alias,
     # style of the manifest it'll be digesting.
     sf = SignatureManifest(linesep=mf.linesep)
 
-    sf_digest_algorithm = digest    # No point to make it different
+    sf_digest_algorithm = "SHA-256" if digest is None else digest
     sf.digest_manifest(mf, sf_digest_algorithm)
 
     sig_digest_algorithm = digest  # No point to make it different

--- a/tests/jarutil.py
+++ b/tests/jarutil.py
@@ -171,9 +171,9 @@ class JarutilTest(TestCase):
         key = get_data_fn("ec-key.pem")
         with NamedTemporaryFile() as tmp_jar:
             copyfile(src, tmp_jar.name)
-            cli_sign_jar([tmp_jar.name, cert, key, key_alias])
+            cli_sign_jar(['-d', 'SHA-512', tmp_jar.name, cert, key, key_alias])
             self.verify_wrap(cert, tmp_jar.name,
-                             "Verification of JAR which we just signed failed")
+                             "Verification of JAR which we just signed with SHA-512 failed")
 
 
     def test_sign_with_certchain_and_verify(self):


### PR DESCRIPTION
Option '-d' for `jarutil s` is handled, i.e. the digest algorithm can be specified:
```
jarutil s -d SHA-512 data.jar certificate.pem private-key.pem ALIAS
```
This has been possible since M2Crypto release 0.26.0.