### PR TITLE
Code cleanup suggested by flake8. No logic changes.

### DIFF
--- a/javatools/crypto.py
+++ b/javatools/crypto.py
@@ -55,7 +55,7 @@ def private_key_type(key_file):
     for key, ktype in keytypes:
         try:
             ktype.load_key(key_file)
-        except:
+        except (RSA.RSAError, DSA.DSAError, ValueError):
             continue
         else:
             return key
@@ -131,18 +131,19 @@ def ignore_missing_email_protection_eku_cb(ok, ctx):
     if ctx.get_error_depth() > 0:
         return ok
 
-    # There is also another cause of ERR_INVALID_PURPOSE: incompatible keyUsage.
-    # In this case, we do not want to ignore it; do not modify the default behavior.
+    # There is another cause of ERR_INVALID_PURPOSE: incompatible keyUsage.
+    # Do not modify the default behavior in this case.
     cert = ctx.get_current_cert()
     try:
         key_usage = cert.get_ext('keyUsage').get_value()
-        if 'digitalSignature' not in key_usage and 'nonRepudiation' not in key_usage:
+        if 'digitalSignature' not in key_usage \
+                and 'nonRepudiation' not in key_usage:
             return ok
     except LookupError:
         pass
 
     # Here, keyUsage is either absent, or contains the needed bit(s).
-    # So, ERR_INVALID_PURPOSE is caused by EKU not containing 'emailProtection'.
+    # So ERR_INVALID_PURPOSE is caused by EKU not containing 'emailProtection'.
     # Ignore this error.
     return 1
 

--- a/javatools/distdiff.py
+++ b/javatools/distdiff.py
@@ -53,8 +53,7 @@ __all__ = (
     "DistJarChange", "DistJarAdded", "DistJarRemoved",
     "DistReport", "DistClassReport", "DistJarReport",
     "cli", "main",
-    "cli_dist_diff",
-    "distdiff_optgroup", "default_distdiff_options", )
+    "cli_dist_diff", "default_distdiff_options", )
 
 
 # glob patterns used to trigger a DistTextChange

--- a/javatools/jarutil.py
+++ b/javatools/jarutil.py
@@ -63,7 +63,7 @@ class MissingManifestError(Exception):
     pass
 
 
-def verify(certificate, jar_file, sf_name = None):
+def verify(certificate, jar_file, sf_name=None):
     """
     Verifies signature of a JAR file.
 
@@ -88,13 +88,13 @@ def verify(certificate, jar_file, sf_name = None):
     elif len(sf_files) > 1:
         if sf_name is None:
             msg = "Multiple .SF files in %s, but SF_NAME.SF not specified" \
-                    % jar_file
+                % jar_file
             raise VerificationError(msg)
         elif ('META-INF/' + sf_name) in sf_files:
             sf_filename = 'META-INF/' + sf_name
         else:
             msg = "No .SF file in %s named META-INF/%s (found %d .SF files)" \
-                    % (jar_file, sf_name, len(sf_files))
+                % (jar_file, sf_name, len(sf_files))
             raise VerificationError(msg)
     elif len(sf_files) == 1:
         if sf_name is None:

--- a/javatools/manifest.py
+++ b/javatools/manifest.py
@@ -49,8 +49,7 @@ __all__ = (
     "Manifest", "ManifestSection",
     "SignatureManifest",
     "ManifestKeyException", "MalformedManifest",
-    "main", "cli",
-    "cli_create", "cli_query", "cli_verify", )
+    "main", "cli_create", "cli_query", "cli_verify", )
 
 
 _BUFFERING = 2 ** 14


### PR DESCRIPTION
- Catch specific exceptions instead of everything
- Remove non-existing names from `__all__`
- Shorten some >79 character long lines
- Whitespace cleanup