### PR TITLE
Cosmetic cleanups of CLI apps

### DIFF
--- a/javatools/jarutil.py
+++ b/javatools/jarutil.py
@@ -322,11 +322,12 @@ def cli_verify_jar_signature(argument_list):
 
 
 def usage():
-    print("Usage: jarutil [csv] [options] [argument]...")
+    print("Usage: jarutil command [options] [argument]...")
+    print("Commands:")
     print("   c: create JAR from paths")
     print("   s: sign JAR")
     print("   v: verify JAR signature")
-    print("Give option \"-h\" for help on particular commands.")
+    print("Give option \"-h\" for help on a particular command.")
     return 1
 
 

--- a/javatools/manifest.py
+++ b/javatools/manifest.py
@@ -1018,7 +1018,7 @@ def usage(error_msg=None):
     return 1
 
 
-def main(args):
+def main(args=sys.argv):
     """
     main entry point for the manifest CLI
     """

--- a/javatools/manifest.py
+++ b/javatools/manifest.py
@@ -1009,11 +1009,12 @@ def cli_query(args):
 def usage(error_msg=None):
     if error_msg is not None:
         print(error_msg)
-    print("Usage: manifest [cqv] [options]...")
+    print("Usage: manifest command [options]...")
+    print("Commands:")
     print("    c: create a manifest")
     print("    q: query manifest for values")
     print("    v: verify manifest checksums")
-    print("Give option \"-h\" for help on particular commands.")
+    print("Give option \"-h\" for help on a particular command.")
     return 1
 
 

--- a/javatools/manifest.py
+++ b/javatools/manifest.py
@@ -965,7 +965,7 @@ def cli_create(argument_list):
 
 def cli_verify(args):
     if len(args) != 1 or "-h" in args:
-        print "Usage: manifest v [--ignore=PATH] JAR_FILE"
+        print("Usage: manifest v [--ignore=PATH] JAR_FILE")
         return 2
 
     jarfn = args[0]
@@ -976,8 +976,8 @@ def cli_verify(args):
 
     errors = mf.verify_jar_checksums(jarfn)
     if len(errors) > 0:
-        print "Verify failed, no matching checksums for files: %s" \
-              % ", ".join(errors)
+        print("Verify failed, no matching checksums for files: %s" \
+              % ", ".join(errors))
         return 1
 
     else:
@@ -986,7 +986,7 @@ def cli_verify(args):
 
 def cli_query(args):
     if len(args) < 2 or "-h" in args:
-        print "Usage: manifest file.jar key_to_query..."
+        print("Usage: manifest file.jar key_to_query...")
         return 1
 
     zf = ZipFile(args[0])
@@ -998,17 +998,17 @@ def cli_query(args):
         if len(s) > 1:
             mfs = mf.sub_sections.get(s[0])
             if mfs:
-                print q, "=", mfs.get(s[1])
+                print(q, "=", mfs.get(s[1]))
             else:
-                print q, ": No such section"
+                print(q, ": No such section")
 
         else:
-            print q, "=", mf.get(s[0])
+            print(q, "=", mf.get(s[0]))
 
 
 def usage(error_msg=None):
     if error_msg is not None:
-        print error_msg
+        print(error_msg)
     print("Usage: manifest [cqv] [options]...")
     print("    c: create a manifest")
     print("    q: query manifest for values")


### PR DESCRIPTION
* Usage texts corrected.
* `manifest` actually failed to run as a stand-alone CLI app. Fixed.