### PR TITLE
Implemented support for Python 3

### DIFF
--- a/cheetah_cmd.py
+++ b/cheetah_cmd.py
@@ -26,10 +26,14 @@ from distutils.core import Command
 from distutils.util import newer
 from distutils.command.build_py import build_py
 from glob import glob
-from itertools import izip
 from os import makedirs
 from os.path import basename, exists, join, splitext
 
+# Python 2/3:
+try:
+    from itertools import izip			# Python 2
+except ImportError:
+    from builtins import zip as izip		# Python 3
 
 DEFAULT_CONFIG = "extras/cheetah.cfg"
 

--- a/javatools/__init__.py
+++ b/javatools/__init__.py
@@ -905,7 +905,7 @@ class JavaClassInfo(object):
                     # the event that this was a method or field on the
                     # array, we'll throw away that as well, and just
                     # emit the type contained in the array.
-                    t, _buff = _next_argsig(buffer(pv))
+                    t = _typeseq(pv)
                     if t[1] == "L":
                         pv = _pretty_type(t[1:])
                     else:
@@ -2161,33 +2161,31 @@ def pretty_generic(signature):
     return signature
 
 
-def _next_argsig(buff):
+def _next_argsig(s):
     """
-    given a buffer, find the next complete argument signature and
-    return it and a new buffer advanced past that point
+    given a string, find the next complete argument signature and
+    return it and a new string advanced past that point
     """
 
-    c = buff[0]
+    c = s[0]
 
     if c in "BCDFIJSVZ":
-        result = (c, buffer(buff, 1))
+        result = (c, s[1:])
 
     elif c == "[":
-        d, buff = _next_argsig(buffer(buff, 1))
-        result = (c + d, buff)
+        d, s = _next_argsig(s[1:])
+        result = (c + d, s[len(d)+1:])
 
     elif c == "L":
-        s = buff[:]
         i = s.find(';') + 1
-        result = (s[:i], buffer(buff, i))
+        result = (s[:i], s[i+1:])
 
     elif c == "(":
-        s = buff[:]
         i = s.find(')') + 1
-        result = (s[:i], buffer(buff, i))
+        result = (s[:i], s[i:])
 
     else:
-        raise Unimplemented("_next_argsig is %r in %r" % (c, str(buff)))
+        raise Unimplemented("_next_argsig is %r in %r" % (c, s))
 
     return result
 
@@ -2197,9 +2195,9 @@ def _typeseq_iter(s):
     iterate through all of the type signatures in a sequence
     """
 
-    buff = buffer(str(s))
-    while buff:
-        t, buff = _next_argsig(buff)
+    s = str(s)
+    while s:
+        t, s = _next_argsig(s)
         yield t
 
 
@@ -2216,7 +2214,7 @@ def _pretty_typeseq(type_s):
     iterator of pretty versions of _typeseq_iter
     """
 
-    return (_pretty_type(t) for t in _typeseq_iter(type_s))
+    return (_pretty_type(t) for t in _typeseq(type_s))
 
 
 def _pretty_type(s, offset=0):
@@ -2281,15 +2279,6 @@ def _pretty_class(s):
 
     # well that's easy.
     return s.replace("/", ".")
-
-
-def _clean_array_const(s):
-    """
-    de-array a constant type.
-    """
-
-    t, b = _next_argsig(buffer(s))
-    return (t, str(b))
 
 
 # -----

--- a/javatools/__init__.py
+++ b/javatools/__init__.py
@@ -188,7 +188,7 @@ class JavaConstantPool(object):
         # but not data
         hackpass = False
 
-        for _i in xrange(0, count):
+        for _i in range(0, count):
 
             if hackpass:
                 # previous item was a long or double
@@ -250,7 +250,7 @@ class JavaConstantPool(object):
         constant pool entries.
         """
 
-        for i in xrange(1, len(self.consts)):
+        for i in range(1, len(self.consts)):
             t, _v = self.consts[i]
             if t:
                 yield (i, t, self.deref_const(i))
@@ -262,7 +262,7 @@ class JavaConstantPool(object):
         pool entries.
         """
 
-        for i in xrange(1, len(self.consts)):
+        for i in range(1, len(self.consts)):
             t, v = self.pretty_const(i)
             if t:
                 yield (i, t, v)
@@ -366,7 +366,7 @@ class JavaAttributes(dict):
         cval = self.cpool.deref_const
 
         (count,) = unpacker.unpack_struct(_H)
-        for _i in xrange(0, count):
+        for _i in range(0, count):
             (name, size) = unpacker.unpack_struct(_HI)
             self[cval(name)] = unpacker.read(size)
 
@@ -1207,7 +1207,7 @@ class JavaMemberInfo(object):
 
                     if for_params:
                         (param_count, ) = up.unpack_struct(_B)
-                        annos = (tuple(unp()) for i in xrange(param_count))
+                        annos = (tuple(unp()) for i in range(param_count))
                     else:
                         annos = unp()
                     annos = tuple(annos)
@@ -1847,7 +1847,7 @@ class JavaAnnotation(dict):
     def unpack(self, unpacker):
         self.type_ref, count = unpacker.unpack_struct(_HH)
 
-        for _i in xrange(0, count):
+        for _i in range(0, count):
             key_ref, = unpacker.unpack_struct(_H)
             val = _unpack_annotation_val(unpacker, self.cpool)
 
@@ -1931,7 +1931,7 @@ def _annotation_val_eq(left_tag, left_data, left_cpool,
         if len(left_data) != len(right_data):
             return False
 
-        for index in xrange(0, len(left_data)):
+        for index in range(0, len(left_data)):
             ld = left_data[index]
             rd = right_data[index]
             if not _annotation_val_eq(ld[0], ld[1], left_cpool,
@@ -1964,7 +1964,7 @@ def _unpack_annotation_val(unpacker, cpool):
     elif tag == '[':
         data = list()
         count, = unpacker.unpack_struct(_H)
-        for _i in xrange(0, count):
+        for _i in range(0, count):
             data.append(_unpack_annotation_val(unpacker, cpool))
 
     return (tag, data)
@@ -2095,7 +2095,7 @@ def _pretty_const_type_val(typecode, val):
 
     if typecode == CONST_Utf8:
         typestr = "Utf8"  # formerly Asciz, which was considered Java bug
-        if isinstance(val, unicode):
+        if not isinstance(val, str):	# Py2, val is 'unicode'
             val = repr(val)[2:-1]  # trim off the surrounding u"" (HACK)
         else:
             val = repr(val)[1:-1]  # trim off the surrounding "" (HACK)

--- a/javatools/__init__.py
+++ b/javatools/__init__.py
@@ -2362,7 +2362,7 @@ def unpack_classfile(filename):
     """
 
     with open(filename, "rb", _BUFFERING) as fd:
-        return unpack_class(fd)
+        return unpack_class(fd.read())
 
 
 #

--- a/javatools/__init__.py
+++ b/javatools/__init__.py
@@ -65,7 +65,6 @@ __all__ = (
 
 # the four bytes at the start of every class file
 JAVA_CLASS_MAGIC = (0xCA, 0xFE, 0xBA, 0xBE)
-JAVA_CLASS_MAGIC_STR = "\xca\xfe\xba\xbe"
 
 
 _BUFFERING = 2 ** 14
@@ -2322,9 +2321,10 @@ def is_class_file(filename):
     """
 
     with open(filename, "rb") as fd:
-        c = fd.read(4)
-
-    return c == JAVA_CLASS_MAGIC_STR
+        c = fd.read(len(JAVA_CLASS_MAGIC))
+        if isinstance(c, str):      # Python 2
+            c = map(ord, c)
+        return tuple(c) == JAVA_CLASS_MAGIC
 
 
 def unpack_class(data, magic=None):

--- a/javatools/__init__.py
+++ b/javatools/__init__.py
@@ -31,12 +31,14 @@ References
 """  # noqa
 
 
-from functools import partial
+import sys
 
 from .dirutils import fnmatches
 from .opcodes import disassemble
 from .pack import compile_struct, unpack, UnpackException
 
+if sys.version_info > (3,):
+    buffer = memoryview
 
 __all__ = (
     "JavaClassInfo", "JavaConstantPool", "JavaMemberInfo",

--- a/javatools/classdiff.py
+++ b/javatools/classdiff.py
@@ -28,7 +28,7 @@ added fields or methods, deprecation changes, etc.
 import sys
 
 from abc import ABCMeta
-from future.utils import listvalues, with_metaclass
+from future.utils import with_metaclass
 from argparse import ArgumentParser, Action
 
 try:

--- a/javatools/classdiff.py
+++ b/javatools/classdiff.py
@@ -28,8 +28,13 @@ added fields or methods, deprecation changes, etc.
 import sys
 
 from abc import ABCMeta
-from itertools import izip
+from future.utils import listvalues, with_metaclass
 from argparse import ArgumentParser, Action
+
+try:
+    from itertools import izip
+except ImportError:
+    from builtins import zip as izip
 
 from . import unpack_classfile
 from .change import GenericChange, SuperChange
@@ -199,7 +204,7 @@ class ClassSignatureChange(GenericChange):
         return c.pretty_signature()
 
 
-class AnnotationsChange(GenericChange):
+class AnnotationsChange(with_metaclass(ABCMeta, GenericChange)):
 
     __metaclass__ = ABCMeta
 
@@ -215,7 +220,7 @@ class AnnotationsChange(GenericChange):
         return [anno.pretty_annotation() for anno in annos]
 
 
-class InvisibleAnnotationsChange(AnnotationsChange):
+class InvisibleAnnotationsChange(with_metaclass(ABCMeta, AnnotationsChange)):
 
     __metaclass__ = ABCMeta
 
@@ -251,7 +256,7 @@ class ClassInfoChange(SuperChange):
                     ClassSignatureChange)
 
 
-class MemberSuperChange(SuperChange):
+class MemberSuperChange(with_metaclass(ABCMeta, SuperChange)):
     """
     basis for FieldChange and MethodChange
     """
@@ -265,7 +270,7 @@ class MemberSuperChange(SuperChange):
         return "%s: %s" % (self.label, self.ldata.pretty_descriptor())
 
 
-class MemberAdded(Addition):
+class MemberAdded(with_metaclass(ABCMeta, Addition)):
     """
     basis for FieldAdded and MethodAdded
     """
@@ -279,7 +284,7 @@ class MemberAdded(Addition):
         return "%s: %s" % (self.label, self.rdata.pretty_descriptor())
 
 
-class MemberRemoved(Removal):
+class MemberRemoved(with_metaclass(ABCMeta, Removal)):
     """
     basis for FieldChange and MethodChange
     """
@@ -293,7 +298,7 @@ class MemberRemoved(Removal):
         return "%s: %s" % (self.label, self.ldata.pretty_descriptor())
 
 
-class ClassMembersChange(SuperChange):
+class ClassMembersChange(with_metaclass(ABCMeta, SuperChange)):
     """
     basis for ClassFieldsChange and ClassMethodsChange
     """

--- a/javatools/classinfo.py
+++ b/javatools/classinfo.py
@@ -22,6 +22,7 @@ Let's pretend to be the javap tool shipped with many Java SDKs
 :license: LGPL
 """
 
+from __future__ import print_function
 
 import sys
 import javatools.opcodes as opcodes
@@ -67,47 +68,47 @@ def should_show(options, member):
 def print_field(options, field):
 
     if options.indent:
-        print "   ",
+        print("   "),
 
-    print "%s;" % field.pretty_descriptor()
+    print("%s;" % field.pretty_descriptor())
 
     if options.sigs:
-        print "  Signature:", field.get_signature()
+        print("  Signature:", field.get_signature())
 
     if options.verbose:
         if field.get_annotations():
-            print "  RuntimeVisibleAnnotations:"
+            print("  RuntimeVisibleAnnotations:")
             index = 0
             for anno in field.get_annotations():
-                print "  %i: %s" % index, anno.pretty_annotation()
+                print("  %i: %s" % index, anno.pretty_annotation())
 
         cv = field.get_constantvalue()
         if cv is not None:
             t, v = field.cpool.pretty_const(cv)
             if t:
-                print "  Constant value:", t, v
-        print
+                print("  Constant value:", t, v)
+        print()
 
 
 def print_method(options, method):
     if options.indent:
-        print "   ",
+        print("   "),
 
-    print "%s;" % method.pretty_descriptor()
+    print("%s;" % method.pretty_descriptor())
 
     if options.sigs:
-        print "  Signature:", method.get_signature()
+        print("  Signature:", method.get_signature())
 
     if method.get_annotations():
-        print "  RuntimeVisibleAnnotations:"
+        print("  RuntimeVisibleAnnotations:")
         index = 0
         for anno in method.get_annotations():
-            print "  %i: %s" % (index, anno.pretty_annotation())
+            print("  %i: %s" % (index, anno.pretty_annotation()))
 
     code = method.get_code()
     if options.disassemble and code:
 
-        print "  Code:"
+        print("  Code:")
 
         if options.verbose:
             # the arg count is the number of arguments consumed from
@@ -118,46 +119,46 @@ def print_method(options, method):
             if not method.is_static():
                 argsc += 1
 
-            print "   Stack=%i, Locals=%i, Args_size=%i" % \
-                (code.max_stack, code.max_locals, argsc)
+            print("   Stack=%i, Locals=%i, Args_size=%i" % \
+                (code.max_stack, code.max_locals, argsc))
 
         for line in code.disassemble():
             opname = opcodes.get_opname_by_code(line[1])
             args = line[2]
             if args:
                 args = ", ".join(str(arg) for arg in args)
-                print "   %i:\t%s\t%s" % (line[0], opname, args)
+                print("   %i:\t%s\t%s" % (line[0], opname, args))
             else:
-                print "   %i:\t%s" % (line[0], opname)
+                print("   %i:\t%s" % (line[0], opname))
 
         exps = code.exceptions
         if exps:
-            print "  Exception table:"
-            print "   from\tto\ttarget\ttype"
+            print("  Exception table:")
+            print("   from\tto\ttarget\ttype")
             for e in exps:
                 ctype = e.pretty_catch_type()
-                print "  % 4i\t% 4i\t% 4i\t%s" % \
-                    (e.start_pc, e.end_pc, e.handler_pc, ctype)
+                print("  % 4i\t% 4i\t% 4i\t%s" % \
+                    (e.start_pc, e.end_pc, e.handler_pc, ctype))
 
     if options.verbose:
         if method.is_deprecated():
-            print "  Deprecated: true"
+            print("  Deprecated: true")
 
         if method.is_synthetic():
-            print "  Synthetic: true"
+            print("  Synthetic: true")
 
         if method.is_bridge():
-            print "  Bridge: true"
+            print("  Bridge: true")
 
         if method.is_varargs():
-            print "  Varargs: true"
+            print("  Varargs: true")
 
     if options.lines and code:
         lnt = method.get_code().get_linenumbertable()
         if lnt:
-            print "  LineNumberTable:"
+            print("  LineNumberTable:")
             for o, l in lnt:
-                print "   line %i: %i" % (l, o)
+                print("   line %i: %i" % (l, o))
 
     if options.locals and code:
         if method.cpool:
@@ -169,43 +170,43 @@ def print_method(options, method):
         lvtt = method.get_code().get_localvariabletypetable()
 
         if lvt:
-            print "  LocalVariableTable:"
-            print "   Start  Length  Slot\tName\tDescriptor"
+            print("  LocalVariableTable:")
+            print("   Start  Length  Slot\tName\tDescriptor")
             for o, l, n, d, i in lvt:
                 line = (str(o), str(l), str(i), cval(n), cval(d))
-                print "   %s" % "\t".join(line)
+                print("   %s" % "\t".join(line))
 
         if lvtt:
-            print "  LocalVariableTypeTable:"
-            print "   Start  Length  Slot\tName\tSignature"
+            print("  LocalVariableTypeTable:")
+            print("   Start  Length  Slot\tName\tSignature")
             for o, l, n, s, i in lvtt:
                 line = (str(o), str(l), str(i), cval(n), cval(s))
-                print "   %s" % "\t".join(line)
+                print("   %s" % "\t".join(line))
 
     if options.verbose:
         exps = method.pretty_exceptions()
         if exps:
-            print "  Exceptions:"
+            print("  Exceptions:")
             for e in exps:
-                print "   throws", e
+                print("   throws", e)
 
-        print
+        print()
 
 
 def cli_class_provides(options, info):
-    print "class %s provides:" % info.pretty_this()
+    print("class %s provides:" % info.pretty_this())
 
     for provided in sorted(info.get_provides(options.api_ignore)):
-        print " ", provided
-    print
+        print(" ", provided)
+    print()
 
 
 def cli_class_requires(options, info):
-    print "class %s requires:" % info.pretty_this()
+    print("class %s requires:" % info.pretty_this())
 
     for required in sorted(info.get_requires(options.api_ignore)):
-        print " ", required
-    print
+        print(" ", required)
+    print()
 
 
 def cli_print_classinfo(options, info):
@@ -218,33 +219,33 @@ def cli_print_classinfo(options, info):
 
     sourcefile = info.get_sourcefile()
     if sourcefile:
-        print "Compiled from \"%s\"" % sourcefile
+        print("Compiled from \"%s\"" % sourcefile)
 
-    print info.pretty_descriptor(),
+    print(info.pretty_descriptor()),
 
     if options.verbose or options.show == SHOW_HEADER:
-        print
+        print()
         if info.get_sourcefile():
-            print "  SourceFile: \"%s\"" % info.get_sourcefile()
+            print("  SourceFile: \"%s\"" % info.get_sourcefile())
         if info.get_signature():
-            print "  Signature:", info.get_signature()
+            print("  Signature:", info.get_signature())
 
         if info.get_annotations():
-            print "  RuntimeVisibleAnnotations:"
+            print("  RuntimeVisibleAnnotations:")
             index = 0
             for anno in info.get_annotations():
-                print "  %i: %s" % (index, anno.pretty_annotation())
+                print("  %i: %s" % (index, anno.pretty_annotation()))
 
         if info.get_enclosingmethod():
-            print "  EnclosingMethod:", info.get_enclosingmethod()
+            print("  EnclosingMethod:", info.get_enclosingmethod())
         major, minor = info.get_version()
-        print "  minor version:", major
-        print "  major version:", minor
+        print("  minor version:", major)
+        print("  major version:", minor)
         platform = platform_from_version(*info.version) or "unknown"
-        print "  Platform:", platform
+        print("  Platform:", platform)
 
     if options.constpool:
-        print "  Constants pool:"
+        print("  Constants pool:")
 
         # we don't use the info.pretty_constants() generator here
         # because we actually want numbers for the entries, and that
@@ -256,13 +257,12 @@ def cli_print_classinfo(options, info):
             if t:
                 # skipping the None consts, which would be the entries
                 # comprising the second half of a long or double value
-                print "const #%i = %s\t%s;" % (i, t, v)
-        print
-
+                print("const #%i = %s\t%s;" % (i, t, v))
+        print()
     if options.show == SHOW_HEADER:
         return
 
-    print "{"
+    print("{")
 
     for field in info.fields:
         if should_show(options, field):
@@ -272,9 +272,8 @@ def cli_print_classinfo(options, info):
         if should_show(options, method):
             print_method(options, method)
 
-    print "}"
-    print
-
+    print("}")
+    print()
     return 0
 
 

--- a/javatools/classinfo.py
+++ b/javatools/classinfo.py
@@ -252,7 +252,7 @@ def cli_print_classinfo(options, info):
         # generator skips them.
         cpool = info.cpool
 
-        for i in xrange(1, len(cpool.consts)):
+        for i in range(1, len(cpool.consts)):
             t, v = cpool.pretty_const(i)
             if t:
                 # skipping the None consts, which would be the entries

--- a/javatools/dirutils.py
+++ b/javatools/dirutils.py
@@ -98,8 +98,7 @@ def _gen_from_dircmp(dc, lpath, rpath):
     do the work of comparing the dircmp
     """
 
-    left_only = dc.left_only
-    left_only.sort()
+    left_only = sorted(dc.left_only)
 
     for f in left_only:
         fp = join(dc.left, f)
@@ -111,8 +110,7 @@ def _gen_from_dircmp(dc, lpath, rpath):
         else:
             yield (LEFT, relpath(fp, lpath))
 
-    right_only = dc.right_only
-    right_only.sort()
+    right_only = sorted(dc.right_only)
 
     for f in right_only:
         fp = join(dc.right, f)
@@ -124,20 +122,17 @@ def _gen_from_dircmp(dc, lpath, rpath):
         else:
             yield (RIGHT, relpath(fp, rpath))
 
-    diff_files = dc.diff_files
-    diff_files.sort()
+    diff_files = sorted(dc.diff_files)
 
     for f in diff_files:
         yield (DIFF, join(relpath(dc.right, rpath), f))
 
-    same_files = dc.same_files
-    same_files.sort()
+    same_files = sorted(dc.same_files)
 
     for f in same_files:
         yield (BOTH, join(relpath(dc.left, lpath), f))
 
-    subdirs = dc.subdirs.values()
-    subdirs.sort()
+    subdirs = sorted(dc.subdirs.values())
     for sub in subdirs:
         for event in _gen_from_dircmp(sub, lpath, rpath):
             yield event

--- a/javatools/distdiff.py
+++ b/javatools/distdiff.py
@@ -191,13 +191,10 @@ class DistManifestChange(DistContentChange):
 
     def collect_impl(self):
         if self.is_change():
-            with self.open_left(mode="rt") as fd:
-                left_m = Manifest()
-                left_m.parse(fd)
-
-            with self.open_right(mode="rt") as fd:
-                right_m = Manifest()
-                right_m.parse(fd)
+            left_m = Manifest()
+            left_m.parse_file(self.left_fn())
+            right_m = Manifest()
+            right_m.parse_file(self.right_fn())
 
             yield ManifestChange(left_m, right_m)
 

--- a/javatools/distdiff.py
+++ b/javatools/distdiff.py
@@ -27,7 +27,11 @@ be checked for deep differences.
 
 import sys
 
-from itertools import izip_longest
+try:
+    from itertools import izip_longest
+except ImportError:
+    from future.moves.itertools import zip_longest as izip_longest
+
 from multiprocessing import cpu_count
 from argparse import ArgumentParser
 from os.path import join

--- a/javatools/distinfo.py
+++ b/javatools/distinfo.py
@@ -22,6 +22,7 @@ distribution of mixed class files and JARs.
 :license: LGPL
 """
 
+from __future__ import print_function
 
 import sys
 
@@ -198,19 +199,19 @@ def _collect_dist(pathn):
 
 
 def cli_dist_provides(options, info):
-    print "distribution provides:"
+    print("distribution provides:")
 
     for provided in sorted(info.get_provides(options.api_ignore)):
-        print " ", provided
-    print
+        print(" ", provided)
+    print()
 
 
 def cli_dist_requires(options, info):
-    print "distribution requires:"
+    print("distribution requires:")
 
     for required in sorted(info.get_requires(options.api_ignore)):
-        print " ", required
-    print
+        print(" ", required)
+    print()
 
 
 def cli_distinfo(options, info):

--- a/javatools/distinfo.py
+++ b/javatools/distinfo.py
@@ -89,9 +89,9 @@ class DistInfo(object):
 
         for entry in self.get_jars():
             ji = self.get_jarinfo(entry)
-            for sym, data in ji.get_requires().iteritems():
+            for sym, data in ji.get_requires().items():
                 req.setdefault(sym, []).append((REQ_BY_JAR, entry, data))
-            for sym, data in ji.get_provides().iteritems():
+            for sym, data in ji.get_provides().items():
                 prov.setdefault(sym, []).append((PROV_BY_JAR, entry, data))
                 p.add(sym)
             ji.close()
@@ -105,7 +105,7 @@ class DistInfo(object):
             for sym in ci.get_provides(private=True):
                 p.add(sym)
 
-        req = dict((k, v) for k, v in req.iteritems() if k not in p)
+        req = dict((k, v) for k, v in req.items() if k not in p)
 
         self._requires = req
         self._provides = prov
@@ -121,7 +121,7 @@ class DistInfo(object):
 
         d = self._requires
         if ignored:
-            d = dict((k, v) for k, v in d.iteritems()
+            d = dict((k, v) for k, v in d.items()
                      if not fnmatches(k, *ignored))
         return d
 
@@ -137,7 +137,7 @@ class DistInfo(object):
 
         d = self._provides
         if ignored:
-            d = dict((k, v) for k, v in d.iteritems()
+            d = dict((k, v) for k, v in d.items()
                      if not fnmatches(k, *ignored))
         return d
 

--- a/javatools/jardiff.py
+++ b/javatools/jardiff.py
@@ -192,11 +192,18 @@ class JarManifestChange(JarContentChange):
         if self.is_change():
             with self.open_left() as lfd:
                 lm = Manifest()
-                lm.parse(lfd.read())
+                # Zipfile returns binary content. Manifest is encoded in UTF-8. TODO: refactor
+                data = lfd.read()
+                if not isinstance(data, str):   # Py3
+                    data = data.decode('utf-8')
+                lm.parse(data)
 
             with self.open_right() as rfd:
                 rm = Manifest()
-                rm.parse(rfd.read())
+                data = rfd.read()
+                if not isinstance(data, str):   # Py3
+                    data = data.decode('utf-8')
+                rm.parse(data)
 
             yield ManifestChange(lm, rm)
 
@@ -212,11 +219,17 @@ class JarSignatureFileChange(JarContentChange):
         if self.is_change():
             with self.open_left() as lfd:
                 lm = Manifest()
-                lm.parse(lfd.read())
+                data = lfd.read()
+                if not isinstance(data, str):   # Py3
+                    data = data.decode('utf-8')
+                lm.parse(data)
 
             with self.open_right() as rfd:
                 rm = Manifest()
-                rm.parse(rfd.read())
+                data = rfd.read()
+                if not isinstance(data, str):   # Py3
+                    data = data.decode('utf-8')
+                rm.parse(data)
 
             yield SignatureManifestChange(lm, rm)
 

--- a/javatools/jarinfo.py
+++ b/javatools/jarinfo.py
@@ -106,7 +106,7 @@ class JarInfo(object):
             for sym in ci.get_provides(private=True):
                 p.add(sym)
 
-        req = dict((k, v) for k, v in req.iteritems() if k not in p)
+        req = dict((k, v) for k, v in req.items() if k not in p)
 
         self._requires = req
         self._provides = prov
@@ -118,7 +118,7 @@ class JarInfo(object):
 
         d = self._requires
         if ignored:
-            d = dict((k, v) for k, v in d.iteritems()
+            d = dict((k, v) for k, v in d.items()
                      if not fnmatches(k, *ignored))
         return d
 
@@ -129,7 +129,7 @@ class JarInfo(object):
 
         d = self._provides
         if ignored:
-            d = dict((k, v) for k, v in d.iteritems()
+            d = dict((k, v) for k, v in d.items()
                      if not fnmatches(k, *ignored))
         return d
 
@@ -226,7 +226,7 @@ def cli_jar_classes(options, jarinfo):
 def cli_jar_provides(options, jarinfo):
     print("jar provides:")
 
-    for provided in sorted(jarinfo.get_provides().iterkeys()):
+    for provided in sorted(jarinfo.get_provides().keys()):
         if not fnmatches(provided, *options.api_ignore):
             print(" ", provided)
     print()
@@ -235,7 +235,7 @@ def cli_jar_provides(options, jarinfo):
 def cli_jar_requires(options, jarinfo):
     print("jar requires:")
 
-    for required in sorted(jarinfo.get_requires().iterkeys()):
+    for required in sorted(jarinfo.get_requires().keys()):
         if not fnmatches(required, *options.api_ignore):
             print(" ", required)
     print()

--- a/javatools/jarinfo.py
+++ b/javatools/jarinfo.py
@@ -21,6 +21,7 @@ printing it out.
 :license: LGPL
 """
 
+from __future__ import print_function
 
 import sys
 
@@ -185,21 +186,21 @@ def cli_jar_manifest_info(options, jarinfo):
     mf = jarinfo.get_manifest()
 
     if not mf:
-        print "Manifest not present."
-        print
+        print("Manifest not present.")
+        print()
         return
 
-    print "Manifest main section:"
+    print("Manifest main section:")
     for k, v in sorted(mf.items()):
-        print "  %s: %s" % (k, v)
+        print("  %s: %s" % (k, v))
 
     for _name, sect in sorted(mf.sub_sections.items()):
-        print
-        print "Manifest sub-section:"
+        print()
+        print("Manifest sub-section:")
         for k, v in sorted(sect.items()):
-            print "  %s: %s" % (k, v)
+            print("  %s: %s" % (k, v))
 
-    print
+    print()
 
 
 def cli_jar_zip_info(options, jarinfo):
@@ -208,36 +209,36 @@ def cli_jar_zip_info(options, jarinfo):
     files, dirs, comp, uncomp = zip_entry_rollup(zipfile)
     prcnt = (float(comp) / float(uncomp)) * 100
 
-    print "Contains %i files, %i directories" % (files, dirs)
-    print "Uncompressed size is %i" % uncomp
-    print "Compressed size is %i (%0.1f%%)" % (comp, prcnt)
-    print
+    print("Contains %i files, %i directories" % (files, dirs))
+    print("Uncompressed size is %i" % uncomp)
+    print("Compressed size is %i (%0.1f%%)" % (comp, prcnt))
+    print()
 
 
 def cli_jar_classes(options, jarinfo):
     for entry in jarinfo.get_classes():
         ci = jarinfo.get_classinfo(entry)
-        print "Entry: ", entry
+        print("Entry: ", entry)
         cli_print_classinfo(options, ci)
-        print
+        print()
 
 
 def cli_jar_provides(options, jarinfo):
-    print "jar provides:"
+    print("jar provides:")
 
     for provided in sorted(jarinfo.get_provides().iterkeys()):
         if not fnmatches(provided, *options.api_ignore):
-            print " ", provided
-    print
+            print(" ", provided)
+    print()
 
 
 def cli_jar_requires(options, jarinfo):
-    print "jar requires:"
+    print("jar requires:")
 
     for required in sorted(jarinfo.get_requires().iterkeys()):
         if not fnmatches(required, *options.api_ignore):
-            print " ", required
-    print
+            print(" ", required)
+    print()
 
 
 def cli_jarinfo(options, info):

--- a/javatools/jarinfo.py
+++ b/javatools/jarinfo.py
@@ -150,7 +150,7 @@ class JarInfo(object):
         """
 
         with self.open(entry) as cfd:
-            return unpack_class(cfd)
+            return unpack_class(cfd.read())
 
 
     def get_manifest(self):

--- a/javatools/jarutil.py
+++ b/javatools/jarutil.py
@@ -138,10 +138,12 @@ def verify(certificate, jar_file, sf_name=None):
     # KEYALIAS.SF is correctly signed.
     # Step 2: Check that it contains correct checksum of the manifest.
     signature_manifest = SignatureManifest()
+    if not isinstance(sf_data, str):  # Py3, there sf_data is bytes
+        sf_data = sf_data.decode('utf-8')   # TODO: how to factor it nicely?
     signature_manifest.parse(sf_data)
 
     jar_manifest = Manifest()
-    jar_manifest.parse(zip_file.read("META-INF/MANIFEST.MF"))
+    jar_manifest.load_from_jar(jar_file)
 
     errors = signature_manifest.verify_manifest(jar_manifest)
     if len(errors) > 0:
@@ -173,13 +175,8 @@ def sign(jar_file, cert_file, key_file, key_alias,
     :return None
     """
 
-    jar = ZipFile(jar_file, "a")
-    if "META-INF/MANIFEST.MF" not in jar.namelist():
-        raise MissingManifestError(
-            "META-INF/MANIFEST.MF not found in %s" % jar_file)
-
     mf = Manifest()
-    mf.parse(jar.read("META-INF/MANIFEST.MF"))
+    mf.load_from_jar(jar_file)
     mf.add_jar_entries(jar_file, digest)
 
     # create a signature manifest, and make it match the line separator
@@ -203,7 +200,9 @@ def sign(jar_file, cert_file, key_file, key_alias,
         new_jar.writestr("META-INF/%s.SF" % key_alias, sf.get_data())
         new_jar.writestr("META-INF/%s.%s" % (key_alias, sig_block_extension),
                          sigdata)
+        jar = ZipFile(jar_file, "a")
         for entry in jar.namelist():
+            # TODO: In Py2, namelist() can be of type unicode
             if not entry.upper() == "META-INF/MANIFEST.MF":
                 new_jar.writestr(entry, jar.read(entry))
 

--- a/javatools/jarutil.py
+++ b/javatools/jarutil.py
@@ -83,7 +83,7 @@ def verify(certificate, jar_file, sf_name=None):
 
     # Step 0: get the "key alias", used also for naming of sig-related files.
     zip_file = ZipFile(jar_file)
-    sf_files = filter(file_matches_sigfile, zip_file.namelist())
+    sf_files = [f for f in zip_file.namelist() if file_matches_sigfile(f)]
 
     if len(sf_files) == 0:
         raise JarSignatureMissingError("No .SF file in %s" % jar_file)

--- a/javatools/jarutil.py
+++ b/javatools/jarutil.py
@@ -21,6 +21,8 @@ Java archives
 :license: LGPL
 """
 
+from __future__ import print_function
+
 import argparse
 import os
 import sys
@@ -289,11 +291,11 @@ def cli_sign_jar(argument_list=None):
              args.extra_certs, args.digest, args.output)
 
     except CannotFindKeyTypeError:
-        print "Cannot determine private key type in %s" % args.key_file
+        print("Cannot determine private key type in %s" % args.key_file)
         return 1
 
     except MissingManifestError:
-        print "Manifest missing in jar file %s" % args.jar_file
+        print("Manifest missing in jar file %s" % args.jar_file)
         return 2
 
     return 0
@@ -307,17 +309,17 @@ def cli_verify_jar_signature(argument_list):
 
     usage_message = "jarutil v file.jar trusted_certificate.pem [SF_NAME.SF]"
     if len(argument_list) < 2 or len(argument_list) > 3:
-        print usage_message
+        print(usage_message)
         return 1
 
     jar_file, certificate, sf_name = (argument_list + [None])[:3]
     try:
         verify(certificate, jar_file, sf_name)
     except VerificationError as error_message:
-        print error_message
+        print(error_message)
         return 1
     else:
-        print "Jar verified."
+        print("Jar verified.")
         return 0
 
 

--- a/javatools/manifest.py
+++ b/javatools/manifest.py
@@ -25,6 +25,7 @@ References
 :license: LGPL
 """
 
+from __future__ import print_function
 
 import argparse
 import hashlib

--- a/javatools/manifest.py
+++ b/javatools/manifest.py
@@ -237,6 +237,10 @@ class ManifestSection(OrderedDict):
         self[self.primary_key] = name
 
 
+    def __gt__(self, other_section):
+        # we need just some ordering, no matter which.
+        return self.get_data() > other_section.get_data()
+
     def __setitem__(self, k, v):
         # pylint: disable=W0221
         # we want the behavior of OrderedDict, but don't take the

--- a/javatools/manifest.py
+++ b/javatools/manifest.py
@@ -47,6 +47,8 @@ from .change import GenericChange, SuperChange
 from .change import Addition, Removal
 from .dirutils import fnmatches, makedirsp
 
+if sys.version_info > (3,):
+    buffer = memoryview
 
 __all__ = (
     "ManifestChange", "ManifestSectionChange",
@@ -356,7 +358,7 @@ class Manifest(ManifestSection):
         # the first section is the main one for the manifest. It's
         # also where we will check for our newline separator
         sections = parse_sections(data)
-        self.load(sections.next())
+        self.load(next(sections))
 
         # and all following sections are considered sub-sections
         for section in sections:

--- a/javatools/manifest.py
+++ b/javatools/manifest.py
@@ -35,8 +35,12 @@ import sys
 from base64 import b64encode
 from collections import OrderedDict
 from cStringIO import StringIO
-from itertools import izip
-from os.path import isdir, join, sep, split, walk
+try:
+    from itertools import izip
+except ImportError:
+    from builtins import zip as izip
+from os.path import isdir, join, sep, split
+from os import walk
 from zipfile import ZipFile
 
 from .change import GenericChange, SuperChange

--- a/javatools/manifest.py
+++ b/javatools/manifest.py
@@ -280,25 +280,16 @@ class ManifestSection(OrderedDict):
             self[k] = "".join(vals)
 
 
-    def store(self, stream, linesep=os.linesep):
-        """
-        Serialize this section and write it to a stream
-        """
-
-        for k, v in self.items():
-            stream.write(write_key_val(k, v, linesep))
-
-        stream.write(linesep)
-
-
     def get_data(self, linesep=os.linesep):
         """
         Serialize the section and return it as a string
+        :return str
         """
 
-        stream = StringIO()
-        self.store(stream, linesep)
-        return stream.getvalue()
+        ret = ""
+        for k, v in self.items():
+            ret += write_key_val(k, v, linesep)
+        return ret + linesep
 
 
     def keys_with_suffix(self, suffix):
@@ -383,26 +374,21 @@ class Manifest(ManifestSection):
         Serialize the Manifest to a stream
         """
 
-        # either specified here, specified on the instance, or the OS
-        # default
         linesep = linesep or self.linesep or os.linesep
 
-        ManifestSection.store(self, stream, linesep)
+        stream.write(ManifestSection.get_data(self, linesep))
         for sect in sorted(self.sub_sections.values()):
-            sect.store(stream, linesep)
+            stream.write(sect.get_data(linesep))
 
 
     def get_main_section(self, linesep=None):
         """
-        Serialize just the main section of the manifest and return it as a
-        string
+        Serialize just the main section of the manifest
+        :return str
         """
 
         linesep = linesep or self.linesep or os.linesep
-
-        stream = StringIO()
-        ManifestSection.store(self, stream, linesep)
-        return stream.getvalue()
+        return ManifestSection.get_data(self, linesep)
 
 
     def get_data(self, linesep=None):

--- a/javatools/manifest.py
+++ b/javatools/manifest.py
@@ -34,7 +34,6 @@ import sys
 
 from base64 import b64encode
 from collections import OrderedDict
-from cStringIO import StringIO
 try:
     from itertools import izip
 except ImportError:
@@ -700,15 +699,12 @@ def parse_sections(data):
     if not data:
         return
 
-    if isinstance(data, (str, buffer)):
-        data = StringIO(data)
-
     # our current section
     curr = None
 
-    for lineno, line in enumerate(data):
+    for lineno, line in enumerate(data.splitlines()):
         # Clean up the line
-        cleanline = line.splitlines()[0].replace('\x00', '')
+        cleanline = line.replace('\x00', '')
 
         if not cleanline:
             # blank line means end of current section (if any)

--- a/javatools/manifest.py
+++ b/javatools/manifest.py
@@ -773,16 +773,15 @@ def write_key_val(key, val, linesep):
     ret = ""
 
     if len(key.encode('utf-8')) + len(val.encode("utf-8")) > MANIFEST_MAX_LINE - 4:
-        kvbuffer = StringIO(": ".join((key, val)))
+        kvbuffer = ": ".join((key, val))
     
-        ret += kvbuffer.read(MANIFEST_MAX_LINE - 2)     # 2 for CR, LF
-        part = kvbuffer.read(MANIFEST_MAX_LINE - 3)     # 3 for leading space, CR, LF
+        ret += kvbuffer[0:MANIFEST_MAX_LINE - 2]        # 2 for CR, LF
+        kvbuffer = kvbuffer[MANIFEST_MAX_LINE - 2:]
 
-        while part:
-            entry = linesep + " " + part
-            ret += entry
-            part = kvbuffer.read(MANIFEST_MAX_LINE - 3)
-        kvbuffer.close()
+        while kvbuffer:
+            kvbuffer = linesep + " " + kvbuffer
+            ret += kvbuffer[:MANIFEST_MAX_LINE - 2]
+            kvbuffer = kvbuffer[MANIFEST_MAX_LINE - 2:]
 
     else:
         entry = ": ".join((key, val))

--- a/javatools/manifest.py
+++ b/javatools/manifest.py
@@ -32,6 +32,7 @@ import hashlib
 import os
 import sys
 
+from io import open
 from base64 import b64encode
 from collections import OrderedDict
 try:
@@ -344,7 +345,7 @@ class Manifest(ManifestSection):
         Parse the given file, and attempt to detect the line separator.
         """
 
-        with open(filename, "r", _BUFFERING) as stream:
+        with open(filename, "r", _BUFFERING, newline='') as stream:
             self.parse(stream.read())
 
 
@@ -959,7 +960,7 @@ def cli_create(argument_list):
         # we'll output to the manifest file if specified, and we'll
         # even create parent directories for it, if necessary
         makedirsp(split(args.manifest)[0])
-        output = open(args.manifest, "w")
+        output = open(args.manifest, "w", newline='')
 
     output.write(mf.get_data())
 

--- a/javatools/manifest.py
+++ b/javatools/manifest.py
@@ -346,13 +346,13 @@ class Manifest(ManifestSection):
         """
 
         with open(filename, "r", _BUFFERING) as stream:
-            self.parse(stream)
+            self.parse(stream.read())
 
 
     def parse(self, data):
         """
-        populate instance with values and sub-sections from data in a
-        stream, string, or buffer
+        populate instance with values and sub-sections
+        :type data: str
         """
 
         self.linesep = detect_linesep(data)
@@ -367,18 +367,6 @@ class Manifest(ManifestSection):
             next_section = ManifestSection(None)
             next_section.load(section)
             self.sub_sections[next_section.primary()] = next_section
-
-
-    def store(self, stream, linesep=None):
-        """
-        Serialize the Manifest to a stream
-        """
-
-        linesep = linesep or self.linesep or os.linesep
-
-        stream.write(ManifestSection.get_data(self, linesep))
-        for sect in sorted(self.sub_sections.values()):
-            stream.write(sect.get_data(linesep))
 
 
     def get_main_section(self, linesep=None):
@@ -398,9 +386,11 @@ class Manifest(ManifestSection):
 
         linesep = linesep or self.linesep or os.linesep
 
-        stream = StringIO()
-        self.store(stream, linesep)
-        return stream.getvalue()
+        ret = ManifestSection.get_data(self, linesep)
+        for sect in sorted(self.sub_sections.values()):
+            ret += sect.get_data(linesep)
+
+        return ret
 
 
     def verify_jar_checksums(self, jar_file, strict=True):
@@ -456,6 +446,15 @@ class Manifest(ManifestSection):
             for entry in jar.namelist():
                 if file_skips_verification(entry):
                     continue
+
+                # Note relevant for Py2: ZipFile returns names as Unicode
+                # objects if the corresponding bit in the zip file is set.
+                # See Lib/zipfile.py:_decodeFilename().
+                # Also, https://marcosc.com/2008/12/zip-files-and-encoding-i-hate-you/
+                # TODO: the below reveals the time-bomb, which was earlier masked by StringIO!
+                if not isinstance(entry, str):
+                    entry = str(entry)
+
                 section = self.create_section(entry)
                 section[key_digest] = b64_encoded_digest(jar.read(entry),
                                                          digest)
@@ -682,17 +681,7 @@ def b64_encoded_digest(data, algorithm):
 
 
 def detect_linesep(data):
-    if isinstance(data, (str, buffer)):
-        data = StringIO(data)
-
-    offset = data.tell()
-    line = data.readline()
-    data.seek(offset)
-
-    if line[-2:] == "\r\n":
-        return "\r\n"
-    else:
-        return line[-1]
+    return "\r\n" if "\r\n" in data else "\n"
 
 
 def parse_sections(data):
@@ -976,7 +965,7 @@ def cli_create(argument_list):
         makedirsp(split(args.manifest)[0])
         output = open(args.manifest, "w")
 
-    mf.store(output)
+    output.write(mf.get_data())
 
     if args.manifest:
         output.close()

--- a/javatools/opcodes.py
+++ b/javatools/opcodes.py
@@ -230,6 +230,7 @@ def disassemble(bytecode):
     """
     Generator. Disassembles Java bytecode into a sequence of (offset,
     code, args) tuples
+    :type bytecode: bytes
     """
 
     offset = 0
@@ -238,7 +239,10 @@ def disassemble(bytecode):
     while offset < end:
         orig_offset = offset
 
-        code = ord(bytecode[offset])
+        code = bytecode[offset]
+        if not isinstance(code, int):   # Py3
+            code = ord(code)
+
         offset += 1
 
         args = tuple()

--- a/javatools/pack.py
+++ b/javatools/pack.py
@@ -342,14 +342,14 @@ def unpack(data):
     unpacker:`
     """
 
-    if isinstance(data, (str, buffer)):
+    if isinstance(data, (bytes, buffer)):
         return BufferUnpacker(data)
 
     elif hasattr(data, "read"):
         return StreamUnpacker(data)
 
     else:
-        raise TypeError("unpack requires a str, buffer, or instance"
+        raise TypeError("unpack requires bytes, buffer, or instance"
                         " supporting the read method")
 
 

--- a/javatools/pack.py
+++ b/javatools/pack.py
@@ -34,6 +34,10 @@ or stream.
 from abc import ABCMeta, abstractmethod
 from struct import Struct
 
+import sys
+if sys.version_info > (3,):
+    buffer = memoryview
+
 
 __all__ = (
     "compile_struct", "unpack",
@@ -131,7 +135,7 @@ class Unpacker(object):
 
         (count,) = self.unpack_struct(_H)
         sfmt = compile_struct(fmt)
-        for _i in xrange(count):
+        for _i in range(count):
             yield self.unpack_struct(sfmt)
 
 
@@ -143,7 +147,7 @@ class Unpacker(object):
         """
 
         (count,) = self.unpack_struct(_H)
-        for _i in xrange(count):
+        for _i in range(count):
             yield self.unpack_struct(struct)
 
 
@@ -157,7 +161,7 @@ class Unpacker(object):
         """
 
         (count,) = self.unpack_struct(_H)
-        for _i in xrange(count):
+        for _i in range(count):
             obj = atype(*params, **kwds)
             obj.unpack(self)
             yield obj

--- a/javatools/report.py
+++ b/javatools/report.py
@@ -392,7 +392,7 @@ def _indent(stream, indent, *msgs):
     for x in range(0, indent):
         stream.write("  ")
     for x in msgs:
-        stream.write(x.encode("ascii", "backslashreplace"))
+        stream.write(x)
     stream.write("\n")
 
 

--- a/javatools/report.py
+++ b/javatools/report.py
@@ -389,7 +389,7 @@ def _indent(stream, indent, *msgs):
     """ write a message to stream, with indentation. Also ensures that
     the output encoding of the messages is safe for writing. """
 
-    for x in xrange(0, indent):
+    for x in range(0, indent):
         stream.write("  ")
     for x in msgs:
         stream.write(x.encode("ascii", "backslashreplace"))

--- a/javatools/report.py
+++ b/javatools/report.py
@@ -20,6 +20,7 @@ Classes for representing changes as formatted text.
 :license: LGPL
 """
 
+from __future__ import print_function
 
 import sys
 
@@ -294,7 +295,7 @@ class JSONReportFormat(ReportFormat):
 
         except TypeError:
             # XXX for debugging. Otherwise the wrapping try isn't necessary
-            print data
+            print(data)
             raise
 
 

--- a/javatools/report.py
+++ b/javatools/report.py
@@ -22,6 +22,8 @@ Classes for representing changes as formatted text.
 
 from __future__ import print_function
 
+from future.utils import with_metaclass
+
 import sys
 
 from abc import ABCMeta, abstractmethod
@@ -168,7 +170,7 @@ class Reporter(object):
         self._formats = None
 
 
-class ReportFormat(object):
+class ReportFormat(with_metaclass(ABCMeta, object)):
     """
     Base class of a report format provider. Override to describe a
     concrete format type

--- a/javatools/ziputils.py
+++ b/javatools/ziputils.py
@@ -34,6 +34,10 @@ from zlib import crc32
 
 from .dirutils import LEFT, RIGHT, DIFF, SAME, closing
 
+import sys
+if sys.version_info > (3,):
+    buffer = memoryview
+
 
 __all__ = (
     "compare", "compare_zips",

--- a/javatools/ziputils.py
+++ b/javatools/ziputils.py
@@ -21,7 +21,7 @@ Utilities for discovering entry deltas in a pair of zip files.
 """
 
 
-from cStringIO import StringIO
+from io import BytesIO
 try:
     from itertools import izip_longest
 except ImportError:
@@ -195,7 +195,7 @@ def is_zipstream(data):
     """
 
     if isinstance(data, (str, buffer)):
-        data = StringIO(data)
+        data = BytesIO(data)
 
     if hasattr(data, "read"):
         tell = 0

--- a/javatools/ziputils.py
+++ b/javatools/ziputils.py
@@ -22,7 +22,11 @@ Utilities for discovering entry deltas in a pair of zip files.
 
 
 from cStringIO import StringIO
-from itertools import izip_longest
+try:
+    from itertools import izip_longest
+except ImportError:
+    from future.moves.itertools import zip_longest as izip_longest
+
 from os import walk
 from os.path import getsize, isdir, isfile, islink, join, relpath
 from zipfile import is_zipfile, ZipFile, ZipInfo, _EndRecData

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python2
+#! /usr/bin/env python
 
 # This library is free software; you can redistribute it and/or modify
 # it under the terms of the GNU Lesser General Public License as

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,9 @@ setup(name = "javatools",
       provides = ["javatools", ],
 
       install_requires = ["Cheetah3",
-                          "M2Crypto >= 0.26.0", ],
+                          "M2Crypto >= 0.26.0",
+                          "future",
+                         ],
 
       setup_requires = ["Cheetah3", ],
 

--- a/setup.py
+++ b/setup.py
@@ -67,10 +67,10 @@ setup(name = "javatools",
 
       provides = ["javatools", ],
 
-      install_requires = ["Cheetah",
+      install_requires = ["Cheetah3",
                           "M2Crypto >= 0.26.0", ],
 
-      setup_requires = ["Cheetah", ],
+      setup_requires = ["Cheetah3", ],
 
       platforms = ["python2 >= 2.6", ],
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -944,10 +944,10 @@ class Sample3Test(TestCase):
         self.assertFalse(mi.is_deprecated())
 
         excs = mi.get_exceptions()
-        self.assertEquals(excs, ("java/lang/Exception",))
+        self.assertEqual(excs, ("java/lang/Exception",))
 
         excs = tuple(mi.pretty_exceptions())
-        self.assertEquals(excs, ("java.lang.Exception",))
+        self.assertEqual(excs, ("java.lang.Exception",))
 
 
     def test_method_get_data_default(self):
@@ -990,10 +990,10 @@ class Sample3Test(TestCase):
         self.assertFalse(mi.is_deprecated())
 
         excs = mi.get_exceptions()
-        self.assertEquals(excs, tuple())
+        self.assertEqual(excs, tuple())
 
         excs = tuple(mi.pretty_exceptions())
-        self.assertEquals(excs, tuple())
+        self.assertEqual(excs, tuple())
 
         code = mi.get_code()
         code_excs = code.exceptions
@@ -1049,10 +1049,10 @@ class Sample3Test(TestCase):
         self.assertFalse(mi.is_deprecated())
 
         excs = mi.get_exceptions()
-        self.assertEquals(excs, tuple())
+        self.assertEqual(excs, tuple())
 
         excs = tuple(mi.pretty_exceptions())
-        self.assertEquals(excs, tuple())
+        self.assertEqual(excs, tuple())
 
 
     def test_method_get_last_data(self):
@@ -1094,10 +1094,10 @@ class Sample3Test(TestCase):
         self.assertFalse(mi.is_deprecated())
 
         excs = mi.get_exceptions()
-        self.assertEquals(excs, ("java/lang/Exception",))
+        self.assertEqual(excs, ("java/lang/Exception",))
 
         excs = tuple(mi.pretty_exceptions())
-        self.assertEquals(excs, ("java.lang.Exception",))
+        self.assertEqual(excs, ("java.lang.Exception",))
 
 
     def test_method_set_last_data(self):
@@ -1140,10 +1140,10 @@ class Sample3Test(TestCase):
         self.assertFalse(mi.is_deprecated())
 
         excs = mi.get_exceptions()
-        self.assertEquals(excs, tuple())
+        self.assertEqual(excs, tuple())
 
         excs = tuple(mi.pretty_exceptions())
-        self.assertEquals(excs, tuple())
+        self.assertEqual(excs, tuple())
 
 
 #

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -49,6 +49,11 @@ class Sample1Tests(TestCase):
         fn = get_class_fn("Sample1")
         self.assertTrue(jt.is_class_file(fn))
 
+    def test_is_class(self):
+        fn = get_class_fn("Sample1")
+        with open(fn, "rb") as f:
+            data = f.read()
+        self.assertTrue(jt.is_class(data))
 
     def test_classinfo(self):
         ci = load("Sample1")

--- a/tests/data/test_distdiff/mf1/MANIFEST.MF
+++ b/tests/data/test_distdiff/mf1/MANIFEST.MF
@@ -1,0 +1,3 @@
+Manifest-Version: 1.0
+Created-By: 1.7.0_51 (Oracle Corporation)
+

--- a/tests/data/test_distdiff/mf2/MANIFEST.MF
+++ b/tests/data/test_distdiff/mf2/MANIFEST.MF
@@ -1,0 +1,8 @@
+Manifest-Version: 1.0
+
+Name: filename-which-is-longer-than-80-characters-and-does-not-fit-in-
+ java-manifest-line.txt
+MD5-Digest: JqsNuQ1y4orQuh4i7lEFEA==
+SHA-512-Digest: Y+Iuwvvuur8AXlj7+w7uYHxKpBcEWmigzGN2ewSONVkmjTXnLzZ9Oy
+ 29Xb3fEvxDl3YroUkmCzeVoDkXE73c1w==
+

--- a/tests/distdiff.py
+++ b/tests/distdiff.py
@@ -51,3 +51,9 @@ class DistdiffTest(TestCase):
         left = get_data_fn(os.path.join("test_distdiff", "text1"))
         right = get_data_fn(os.path.join("test_distdiff", "text2"))
         self.assertEqual(1, main(["argv0", left, right]))
+
+    def test_different_manifests(self):
+        left = get_data_fn(os.path.join("test_distdiff", "mf1"))
+        right = get_data_fn(os.path.join("test_distdiff", "mf2"))
+        self.assertEqual(1, main(["argv0", left, right]))
+

--- a/tests/jarutil.py
+++ b/tests/jarutil.py
@@ -46,7 +46,7 @@ class JarutilTest(TestCase):
     def verify_wrap(self, cert, jar, error_prefix):
         try:
             verify(cert, jar)
-        except VerificationError, error_message:
+        except VerificationError as error_message:
             self.fail("%s: %s" % (error_prefix, error_message))
 
     def test_cli_verify_signature_by_javatools(self):
@@ -74,13 +74,13 @@ class JarutilTest(TestCase):
         jar_data = get_data_fn("test_jarutil/multiple-sf-files-all-valid.jar")
         cert = get_data_fn("test_jarutil/javatools-cert.pem")
         sf_file = "KEY1.SF"
-        self.assertEquals(verify(cert, jar_data, sf_file), None)
+        self.assertEqual(verify(cert, jar_data, sf_file), None)
 
     def test_multiple_valid_sf_files_cert2(self):
         jar_data = get_data_fn("test_jarutil/multiple-sf-files-all-valid.jar")
         cert = get_data_fn("test_jarutil/javatools-cert-2.pem")
         sf_file = "KEY2.SF"
-        self.assertEquals(verify(cert, jar_data, sf_file), None)
+        self.assertEqual(verify(cert, jar_data, sf_file), None)
 
     def test_single_sf_file_wrong_cert_specified(self):
         jar_data = get_data_fn("test_jarutil/jarutil-signed.jar")
@@ -93,7 +93,7 @@ class JarutilTest(TestCase):
         jar_data = get_data_fn("test_jarutil/jarutil-signed.jar")
         cert = get_data_fn("test_jarutil/javatools-cert.pem")
         sf_file = "UNUSED.SF"
-        self.assertEquals(verify(cert, jar_data, sf_file), None)
+        self.assertEqual(verify(cert, jar_data, sf_file), None)
 
     def test_ecdsa_pkcs8_verify(self):
         self.cli_verify_wrap("test_jarutil/ec.jar", "test_jarutil/ec-cert.pem")

--- a/tests/jarutil.py
+++ b/tests/jarutil.py
@@ -229,7 +229,8 @@ class JarutilTest(TestCase):
             if "META-INF/MANIFEST.MF" not in entries:
                 self.fail("No META-INF/MANIFEST.MF in just created JAR\n"
                           "JAR content:\n%s" % ", ".join(entries))
-            mf.parse(jar_file.read("META-INF/MANIFEST.MF"))
+
+            mf.load_from_jar(jar_fn)
 
         rmtree(tmp_dir)
 

--- a/tests/manifest.py
+++ b/tests/manifest.py
@@ -85,7 +85,7 @@ class ManifestTest(TestCase):
         mf.parse_file(src_file)
         result = mf.get_data()
 
-        self.assertEquals(
+        self.assertEqual(
             result, expected_result,
             "Manifest load/store does not match with file %s. Received:\n%s"
             % (src_file, result))

--- a/tests/manifest.py
+++ b/tests/manifest.py
@@ -45,7 +45,7 @@ class ManifestTest(TestCase):
 
         # the invocation of the script
         src_jar = get_data_fn("test_manifest/manifest-sample1.jar")
-        with NamedTemporaryFile() as tmp_out:
+        with NamedTemporaryFile(mode="rt") as tmp_out:
             cmd = ["manifest", "c", src_jar, "-m", tmp_out.name]
             cmd.extend(args.split())
 

--- a/tests/manifest.py
+++ b/tests/manifest.py
@@ -24,6 +24,7 @@ license: LGPL v.3
 from . import get_data_fn
 from javatools.manifest import main, Manifest, SignatureManifest
 
+from io import open
 from tempfile import NamedTemporaryFile
 from unittest import TestCase
 
@@ -39,7 +40,7 @@ class ManifestTest(TestCase):
         """
 
         # the result we expect to see from running the script
-        with open(get_data_fn(expected_result)) as f:
+        with open(get_data_fn(expected_result), newline='') as f:
             expected_result = f.read()
 
         # the invocation of the script
@@ -77,7 +78,7 @@ class ManifestTest(TestCase):
 
         # the expected result is identical to what we feed into the
         # manifest parser
-        with open(src_file) as f:
+        with open(src_file, newline='') as f:
             expected_result = f.read()
 
         # create a manifest and parse the chosen test data

--- a/tests/pack.py
+++ b/tests/pack.py
@@ -22,7 +22,7 @@ license: LGPL v.3
 
 
 from abc import ABCMeta, abstractmethod
-from cStringIO import StringIO
+from io import StringIO, BytesIO
 from unittest import TestCase
 
 from javatools.pack import *
@@ -47,7 +47,7 @@ class UnpackerTests(object):
 
 
     def test_type(self):
-        data = "\x05\x04\x03\x02\x01"
+        data = b"\x05\x04\x03\x02\x01"
         up = self.unpack(data)
         self.assertEqual(type(up), self.unpacker_type())
 
@@ -57,12 +57,12 @@ class UnpackerTests(object):
 
 
     def test_basics(self):
-        data = "\x05\x04\x03\x02\x01"
+        data = b"\x05\x04\x03\x02\x01"
 
         with self.unpack(data) as up:
 
             col = up.read(1)
-            self.assertEqual(col, "\x05")
+            self.assertEqual(col, b"\x05")
 
             col = up.unpack(">H")
             self.assertEqual(col, (0x0403,))
@@ -113,7 +113,13 @@ class BufferTest(UnpackerTests, TestCase):
 
 
     def unpack(self, data):
-        return unpack(data)
+        if isinstance(data, bytes):
+            return unpack(data)
+        elif isinstance(data, str): # Py3 here, as in Py2 str is bytes
+            return unpack(data.encode('utf-8'))
+        else:
+            raise TypeError("This test expects instance of 'bytes' or 'str', "
+                            "but {} received".format(type(data).__name__))
 
 
 class StreamTest(UnpackerTests, TestCase):
@@ -123,8 +129,13 @@ class StreamTest(UnpackerTests, TestCase):
 
 
     def unpack(self, data):
-        return unpack(StringIO(data))
-
+        if isinstance(data, bytes):
+            return unpack(BytesIO(data))
+        elif isinstance(data, str): # Py3 here, as in Py2 str is bytes
+            return unpack(BytesIO(data.encode('utf-8')))
+        else:
+            raise TypeError("This test expects instance of 'bytes' or 'str', "
+                            "but {} received".format(type(data).__name__))
 
 #
 # The end.


### PR DESCRIPTION
This pull request makes the project compatible with Python 3.
Closes #53 .

All tests [pass on Python 2.7 and Python 3.6](https://travis-ci.org/KonstantinShemyak/python-javatools/builds/436566138).

No logic is changed and the attempt has been made to isolate the language differences. Some checks might be refactored further (grep for `isinstance`).

I aimed to abide to these principles:

- test for functionality, not for version (`if isinstance()`, not `if PYTHON_VERSION == X`)
- separate the text/binary data as early as possible on input, convert it back as late as possible on output

When(/if) this PR gets accepted, it would be possible to celebrate:

- update `ChangeLog`, `README.md`
- declare Python3 support in the trove classifier.

Additionally it would be nice to have in-project testing framework for both Py2 and Py3.

