### PR TITLE
Towards Py3: compatible syntax, compatible b64encode()

### DIFF
--- a/javatools/__init__.py
+++ b/javatools/__init__.py
@@ -41,7 +41,7 @@ from .pack import compile_struct, unpack, UnpackException
 try:
     buffer
 except NameError:
-    bytes
+    buffer = memoryview
 
 
 __all__ = (
@@ -2100,7 +2100,7 @@ def _pretty_const_type_val(typecode, val):
 
     if typecode == CONST_Utf8:
         typestr = "Utf8"  # formerly Asciz, which was considered Java bug
-        if isinstance(val, unicode):
+        if not isinstance(val, str):
             val = repr(val)[2:-1]  # trim off the surrounding u"" (HACK)
         else:
             val = repr(val)[1:-1]  # trim off the surrounding "" (HACK)

--- a/javatools/jarutil.py
+++ b/javatools/jarutil.py
@@ -85,7 +85,7 @@ def verify(certificate, jar_file, sf_name=None):
 
     # Step 0: get the "key alias", used also for naming of sig-related files.
     zip_file = ZipFile(jar_file)
-    sf_files = filter(file_matches_sigfile, zip_file.namelist())
+    sf_files = [f for f in zip_file.namelist() if file_matches_sigfile(f)]
 
     if len(sf_files) == 0:
         raise JarSignatureMissingError("No .SF file in %s" % jar_file)

--- a/javatools/manifest.py
+++ b/javatools/manifest.py
@@ -505,34 +505,17 @@ class SignatureManifest(Manifest):
         main_key = java_algorithm + "-Digest-Manifest-Main-Attributes"
         sect_key = java_algorithm + "-Digest"
 
-        # determine a digest class to use based on the java-style
-        # algorithm name
         digest = _get_digest(java_algorithm)
-
-        # calculate the checksum for the main manifest section. We'll
-        # be re-using this digest to also calculate the total
-        # checksum.
-        h_all = digest()
-        h_all.update(manifest.get_main_section())
-        self[main_key] = b64encode(h_all.digest())
+        accum = manifest.get_main_section()
+        self[main_key] = b64_encoded_digest(accum, digest)
 
         for sub_section in manifest.sub_sections.values():
             sub_data = sub_section.get_data(linesep)
-
-            # create the checksum of the section body and store it as a
-            # sub-section of our own
-            h_section = digest()
-            h_section.update(sub_data)
             sf_sect = self.create_section(sub_section.primary())
-            sf_sect[sect_key] = b64encode(h_section.digest())
+            sf_sect[sect_key] = b64_encoded_digest(sub_data, digest)
+            accum += sub_data
 
-            # push this data into this total as well.
-            h_all.update(sub_data)
-
-        # after traversing all the sub sections, we now have the
-        # digest of the whole manifest.
-        self[all_key] = b64encode(h_all.digest())
-
+        self[all_key] = b64_encoded_digest(accum, digest)
 
     def verify_manifest_main_checksum(self, manifest):
         """
@@ -659,10 +642,28 @@ class SignatureBlockFileChange(GenericChange):
         return "[binary data]"
 
 
+def _b64encode_to_str(data):
+    """
+    Wrapper around b64encode which takes and returns same-named types
+    on both Python 2 and Python 3.
+    :type data: bytes
+    :return: str
+    """
+    ret = b64encode(data)
+    if not isinstance(ret, str):  # Python3
+        return ret.decode('ascii')
+    else:
+        return ret
+
+
 def b64_encoded_digest(data, algorithm):
+    """
+    :type data: bytes
+    :return: str
+    """
     h = algorithm()
     h.update(data)
-    return b64encode(h.digest())
+    return _b64encode_to_str(h.digest())
 
 
 def detect_linesep(data):
@@ -788,7 +789,7 @@ def digest_chunks(chunks, algorithms=(hashlib.md5, hashlib.sha1)):
         for h in hashes:
             h.update(chunk)
 
-    return [b64encode(h.digest()) for h in hashes]
+    return [_b64encode_to_str(h.digest()) for h in hashes]
 
 
 def file_chunk(filename, size=_BUFFERING):

--- a/javatools/manifest.py
+++ b/javatools/manifest.py
@@ -33,7 +33,8 @@ import sys
 
 from base64 import b64encode
 from collections import OrderedDict
-from os.path import isdir, join, sep, split, walk
+from os.path import isdir, join, sep, split
+from os import walk
 from six import BytesIO
 from six.moves import zip
 from zipfile import ZipFile
@@ -42,6 +43,10 @@ from .change import GenericChange, SuperChange
 from .change import Addition, Removal
 from .dirutils import fnmatches, makedirsp
 
+try:
+    buffer
+except NameError:
+    buffer = memoryview
 
 __all__ = (
     "ManifestChange", "ManifestSectionChange",

--- a/javatools/pack.py
+++ b/javatools/pack.py
@@ -43,6 +43,10 @@ __all__ = (
     "StreamUnpacker", "BufferUnpacker",
 )
 
+try:
+    buffer
+except NameError:
+    buffer = memoryview
 
 # pylint: disable=C0103
 _struct_cache = dict()


### PR DESCRIPTION
This PR is a step towards Python 3 compatibility. It implements the last bullet from https://github.com/obriencj/python-javatools/pull/89#issuecomment-428266618 .

- Remaining bits of syntax which are not compatible with Python 3 are updated.
- "Cross-version" `b64encode()` used.

No Python 2 behavior is affected.