### PR TITLE
Remaining syntax fixes. Simple type updates.

### DIFF
--- a/javatools/__init__.py
+++ b/javatools/__init__.py
@@ -70,7 +70,6 @@ __all__ = (
 
 # the four bytes at the start of every class file
 JAVA_CLASS_MAGIC = (0xCA, 0xFE, 0xBA, 0xBE)
-JAVA_CLASS_MAGIC_STR = "\xca\xfe\xba\xbe"
 
 
 _BUFFERING = 2 ** 14
@@ -2327,9 +2326,10 @@ def is_class_file(filename):
     """
 
     with open(filename, "rb") as fd:
-        c = fd.read(4)
-
-    return c == JAVA_CLASS_MAGIC_STR
+        c = fd.read(len(JAVA_CLASS_MAGIC))
+        if isinstance(c, str):      # Python 2
+            c = map(ord, c)
+        return tuple(c) == JAVA_CLASS_MAGIC
 
 
 def unpack_class(data, magic=None):

--- a/javatools/classinfo.py
+++ b/javatools/classinfo.py
@@ -257,7 +257,7 @@ def cli_print_classinfo(options, info):
         # generator skips them.
         cpool = info.cpool
 
-        for i in xrange(1, len(cpool.consts)):
+        for i in range(1, len(cpool.consts)):
             t, v = cpool.pretty_const(i)
             if t:
                 # skipping the None consts, which would be the entries

--- a/javatools/dirutils.py
+++ b/javatools/dirutils.py
@@ -137,7 +137,7 @@ def _gen_from_dircmp(dc, lpath, rpath):
         yield (BOTH, join(relpath(dc.left, lpath), f))
 
     subdirs = dc.subdirs.values()
-    subdirs.sort()
+    subdirs = sorted(subdirs)
     for sub in subdirs:
         for event in _gen_from_dircmp(sub, lpath, rpath):
             yield event

--- a/javatools/distinfo.py
+++ b/javatools/distinfo.py
@@ -91,9 +91,9 @@ class DistInfo(object):
 
         for entry in self.get_jars():
             ji = self.get_jarinfo(entry)
-            for sym, data in ji.get_requires().iteritems():
+            for sym, data in ji.get_requires().items():
                 req.setdefault(sym, []).append((REQ_BY_JAR, entry, data))
-            for sym, data in ji.get_provides().iteritems():
+            for sym, data in ji.get_provides().items():
                 prov.setdefault(sym, []).append((PROV_BY_JAR, entry, data))
                 p.add(sym)
             ji.close()
@@ -107,7 +107,7 @@ class DistInfo(object):
             for sym in ci.get_provides(private=True):
                 p.add(sym)
 
-        req = dict((k, v) for k, v in req.iteritems() if k not in p)
+        req = dict((k, v) for k, v in req.items() if k not in p)
 
         self._requires = req
         self._provides = prov
@@ -123,7 +123,7 @@ class DistInfo(object):
 
         d = self._requires
         if ignored:
-            d = dict((k, v) for k, v in d.iteritems()
+            d = dict((k, v) for k, v in d.items()
                      if not fnmatches(k, *ignored))
         return d
 
@@ -139,7 +139,7 @@ class DistInfo(object):
 
         d = self._provides
         if ignored:
-            d = dict((k, v) for k, v in d.iteritems()
+            d = dict((k, v) for k, v in d.items()
                      if not fnmatches(k, *ignored))
         return d
 

--- a/javatools/jarinfo.py
+++ b/javatools/jarinfo.py
@@ -110,7 +110,7 @@ class JarInfo(object):
             for sym in ci.get_provides(private=True):
                 p.add(sym)
 
-        req = dict((k, v) for k, v in req.iteritems() if k not in p)
+        req = dict((k, v) for k, v in req.items() if k not in p)
 
         self._requires = req
         self._provides = prov
@@ -122,7 +122,7 @@ class JarInfo(object):
 
         d = self._requires
         if ignored:
-            d = dict((k, v) for k, v in d.iteritems()
+            d = dict((k, v) for k, v in d.items()
                      if not fnmatches(k, *ignored))
         return d
 
@@ -133,7 +133,7 @@ class JarInfo(object):
 
         d = self._provides
         if ignored:
-            d = dict((k, v) for k, v in d.iteritems()
+            d = dict((k, v) for k, v in d.items()
                      if not fnmatches(k, *ignored))
         return d
 
@@ -230,7 +230,7 @@ def cli_jar_classes(options, jarinfo):
 def cli_jar_provides(options, jarinfo):
     print("jar provides:")
 
-    for provided in sorted(jarinfo.get_provides().iterkeys()):
+    for provided in sorted(jarinfo.get_provides().keys()):
         if not fnmatches(provided, *options.api_ignore):
             print(" ", provided)
     print()
@@ -239,7 +239,7 @@ def cli_jar_provides(options, jarinfo):
 def cli_jar_requires(options, jarinfo):
     print("jar requires:")
 
-    for required in sorted(jarinfo.get_requires().iterkeys()):
+    for required in sorted(jarinfo.get_requires().keys()):
         if not fnmatches(required, *options.api_ignore):
             print(" ", required)
     print()

--- a/javatools/manifest.py
+++ b/javatools/manifest.py
@@ -356,7 +356,7 @@ class Manifest(ManifestSection):
         # the first section is the main one for the manifest. It's
         # also where we will check for our newline separator
         sections = parse_sections(data)
-        self.load(sections.next())
+        self.load(next(sections))
 
         # and all following sections are considered sub-sections
         for section in sections:

--- a/javatools/opcodes.py
+++ b/javatools/opcodes.py
@@ -232,6 +232,7 @@ def disassemble(bytecode):
     """
     Generator. Disassembles Java bytecode into a sequence of (offset,
     code, args) tuples
+    :type bytecode: bytes
     """
 
     offset = 0
@@ -240,7 +241,10 @@ def disassemble(bytecode):
     while offset < end:
         orig_offset = offset
 
-        code = ord(bytecode[offset])
+        code = bytecode[offset]
+        if not isinstance(code, int):   # Py3
+            code = ord(code)
+
         offset += 1
 
         args = tuple()

--- a/javatools/pack.py
+++ b/javatools/pack.py
@@ -351,7 +351,7 @@ def unpack(data):
         return StreamUnpacker(data)
 
     else:
-        raise TypeError("unpack requires a str, buffer, or instance"
+        raise TypeError("unpack requires bytes, buffer, or instance"
                         " supporting the read method")
 
 

--- a/javatools/pack.py
+++ b/javatools/pack.py
@@ -344,7 +344,7 @@ def unpack(data):
     unpacker:`
     """
 
-    if isinstance(data, (str, buffer)):
+    if isinstance(data, (bytes, buffer)):
         return BufferUnpacker(data)
 
     elif hasattr(data, "read"):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -49,6 +49,11 @@ class Sample1Tests(TestCase):
         fn = get_class_fn("Sample1")
         self.assertTrue(jt.is_class_file(fn))
 
+    def test_is_class(self):
+        fn = get_class_fn("Sample1")
+        with open(fn, "rb") as f:
+            data = f.read()
+        self.assertTrue(jt.is_class(data))
 
     def test_classinfo(self):
         ci = load("Sample1")
@@ -944,10 +949,10 @@ class Sample3Test(TestCase):
         self.assertFalse(mi.is_deprecated())
 
         excs = mi.get_exceptions()
-        self.assertEquals(excs, ("java/lang/Exception",))
+        self.assertEqual(excs, ("java/lang/Exception",))
 
         excs = tuple(mi.pretty_exceptions())
-        self.assertEquals(excs, ("java.lang.Exception",))
+        self.assertEqual(excs, ("java.lang.Exception",))
 
 
     def test_method_get_data_default(self):
@@ -990,10 +995,10 @@ class Sample3Test(TestCase):
         self.assertFalse(mi.is_deprecated())
 
         excs = mi.get_exceptions()
-        self.assertEquals(excs, tuple())
+        self.assertEqual(excs, tuple())
 
         excs = tuple(mi.pretty_exceptions())
-        self.assertEquals(excs, tuple())
+        self.assertEqual(excs, tuple())
 
         code = mi.get_code()
         code_excs = code.exceptions
@@ -1049,10 +1054,10 @@ class Sample3Test(TestCase):
         self.assertFalse(mi.is_deprecated())
 
         excs = mi.get_exceptions()
-        self.assertEquals(excs, tuple())
+        self.assertEqual(excs, tuple())
 
         excs = tuple(mi.pretty_exceptions())
-        self.assertEquals(excs, tuple())
+        self.assertEqual(excs, tuple())
 
 
     def test_method_get_last_data(self):
@@ -1094,10 +1099,10 @@ class Sample3Test(TestCase):
         self.assertFalse(mi.is_deprecated())
 
         excs = mi.get_exceptions()
-        self.assertEquals(excs, ("java/lang/Exception",))
+        self.assertEqual(excs, ("java/lang/Exception",))
 
         excs = tuple(mi.pretty_exceptions())
-        self.assertEquals(excs, ("java.lang.Exception",))
+        self.assertEqual(excs, ("java.lang.Exception",))
 
 
     def test_method_set_last_data(self):
@@ -1140,10 +1145,10 @@ class Sample3Test(TestCase):
         self.assertFalse(mi.is_deprecated())
 
         excs = mi.get_exceptions()
-        self.assertEquals(excs, tuple())
+        self.assertEqual(excs, tuple())
 
         excs = tuple(mi.pretty_exceptions())
-        self.assertEquals(excs, tuple())
+        self.assertEqual(excs, tuple())
 
 
 #

--- a/tests/pack.py
+++ b/tests/pack.py
@@ -46,18 +46,22 @@ class UnpackerTests(object):
 
 
     def test_type(self):
-        data = "\x05\x04\x03\x02\x01"
+        data = b"\x05\x04\x03\x02\x01"
         up = self.unpack(data)
         self.assertEqual(type(up), self.unpacker_type())
 
 
+    def test_nope(self):
+        self.assertRaises(TypeError, lambda: self.unpack(5))
+
+
     def test_basics(self):
-        data = "\x05\x04\x03\x02\x01"
+        data = b"\x05\x04\x03\x02\x01"
 
         with self.unpack(data) as up:
 
             col = up.read(1)
-            self.assertEqual(col, "\x05")
+            self.assertEqual(col, b"\x05")
 
             col = up.unpack(">H")
             self.assertEqual(col, (0x0403,))
@@ -108,7 +112,13 @@ class BufferTest(UnpackerTests, TestCase):
 
 
     def unpack(self, data):
-        return unpack(data)
+        if isinstance(data, bytes):
+            return unpack(data)
+        elif isinstance(data, str): # Py3 here, as in Py2 str is bytes
+            return unpack(data.encode('utf-8'))
+        else:
+            raise TypeError("This test expects instance of 'bytes' or 'str', "
+                            "but {} received".format(type(data).__name__))
 
 
 class StreamTest(UnpackerTests, TestCase):
@@ -118,8 +128,13 @@ class StreamTest(UnpackerTests, TestCase):
 
 
     def unpack(self, data):
-        return unpack(BytesIO(data))
-
+        if isinstance(data, bytes):
+            return unpack(BytesIO(data))
+        elif isinstance(data, str): # Py3 here, as in Py2 str is bytes
+            return unpack(BytesIO(data.encode('utf-8')))
+        else:
+            raise TypeError("This test expects instance of 'bytes' or 'str', "
+                            "but {} received".format(type(data).__name__))
 
 #
 # The end.


### PR DESCRIPTION
Non-Py3-compatible code left after 4a6cd2139c corrected.
Trivial-to-fix type difference fixes between Py2/Py3 done.

This makes the following tests pass under Python 3.6:

- [x] init
- [ ] classdiff
- [x] classinfo
- [x] crypto
- [ ] distdiff
- [x] distinfo
- [ ] jardiff
- [x] jarinfo
- [ ] jarutil
- [ ] manifest
- [x] pack

This PR does not yet fix fundamental differences between text/binary data handling listed in https://github.com/obriencj/python-javatools/pull/89#issuecomment-428266618 .