### PR TITLE
JAR manifest is stored internally as Unicode

### DIFF
--- a/javatools/distdiff.py
+++ b/javatools/distdiff.py
@@ -187,13 +187,10 @@ class DistManifestChange(DistContentChange):
 
     def collect_impl(self):
         if self.is_change():
-            with self.open_left(mode="rt") as fd:
-                left_m = Manifest()
-                left_m.parse(fd)
-
-            with self.open_right(mode="rt") as fd:
-                right_m = Manifest()
-                right_m.parse(fd)
+            left_m = Manifest()
+            left_m.parse_file(self.left_fn())
+            right_m = Manifest()
+            right_m.parse_file(self.right_fn())
 
             yield ManifestChange(left_m, right_m)
 

--- a/javatools/jarinfo.py
+++ b/javatools/jarinfo.py
@@ -157,23 +157,6 @@ class JarInfo(object):
             return unpack_class(cfd)
 
 
-    def get_manifest(self):
-
-        """ fetch the sections from the MANIFEST.MF file as a Manifest
-        instance, or None if no MANIFEST.MF entry present """
-
-        mf_entry = "META-INF/MANIFEST.MF"
-
-        zipfile = self.get_zipfile()
-        if not zipfile.getinfo(mf_entry):
-            return None
-
-        mf = Manifest()
-        with self.open(mf_entry) as data:
-            mf.parse(data.read())
-        return mf
-
-
     def get_zipfile(self):
         if self.zipfile is None:
             self.zipfile = zip_file(self.filename)

--- a/tests/data/test_distdiff/mf1/MANIFEST.MF
+++ b/tests/data/test_distdiff/mf1/MANIFEST.MF
@@ -1,0 +1,3 @@
+Manifest-Version: 1.0
+Created-By: 1.7.0_51 (Oracle Corporation)
+

--- a/tests/data/test_distdiff/mf2/MANIFEST.MF
+++ b/tests/data/test_distdiff/mf2/MANIFEST.MF
@@ -1,0 +1,8 @@
+Manifest-Version: 1.0
+
+Name: filename-which-is-longer-than-80-characters-and-does-not-fit-in-
+ java-manifest-line.txt
+MD5-Digest: JqsNuQ1y4orQuh4i7lEFEA==
+SHA-512-Digest: Y+Iuwvvuur8AXlj7+w7uYHxKpBcEWmigzGN2ewSONVkmjTXnLzZ9Oy
+ 29Xb3fEvxDl3YroUkmCzeVoDkXE73c1w==
+

--- a/tests/distdiff.py
+++ b/tests/distdiff.py
@@ -51,3 +51,8 @@ class DistdiffTest(TestCase):
         left = get_data_fn(os.path.join("test_distdiff", "text1"))
         right = get_data_fn(os.path.join("test_distdiff", "text2"))
         self.assertEqual(1, main(["argv0", left, right]))
+
+    def test_different_manifests(self):
+        left = get_data_fn(os.path.join("test_distdiff", "mf1"))
+        right = get_data_fn(os.path.join("test_distdiff", "mf2"))
+        self.assertEqual(1, main(["argv0", left, right]))

--- a/tests/jarutil.py
+++ b/tests/jarutil.py
@@ -74,13 +74,13 @@ class JarutilTest(TestCase):
         jar_data = get_data_fn("test_jarutil/multiple-sf-files-all-valid.jar")
         cert = get_data_fn("test_jarutil/javatools-cert.pem")
         sf_file = "KEY1.SF"
-        self.assertEquals(verify(cert, jar_data, sf_file), None)
+        self.assertEqual(verify(cert, jar_data, sf_file), None)
 
     def test_multiple_valid_sf_files_cert2(self):
         jar_data = get_data_fn("test_jarutil/multiple-sf-files-all-valid.jar")
         cert = get_data_fn("test_jarutil/javatools-cert-2.pem")
         sf_file = "KEY2.SF"
-        self.assertEquals(verify(cert, jar_data, sf_file), None)
+        self.assertEqual(verify(cert, jar_data, sf_file), None)
 
     def test_single_sf_file_wrong_cert_specified(self):
         jar_data = get_data_fn("test_jarutil/jarutil-signed.jar")
@@ -93,7 +93,7 @@ class JarutilTest(TestCase):
         jar_data = get_data_fn("test_jarutil/jarutil-signed.jar")
         cert = get_data_fn("test_jarutil/javatools-cert.pem")
         sf_file = "UNUSED.SF"
-        self.assertEquals(verify(cert, jar_data, sf_file), None)
+        self.assertEqual(verify(cert, jar_data, sf_file), None)
 
     def test_ecdsa_pkcs8_verify(self):
         self.cli_verify_wrap("test_jarutil/ec.jar", "test_jarutil/ec-cert.pem")

--- a/tests/jarutil.py
+++ b/tests/jarutil.py
@@ -229,7 +229,8 @@ class JarutilTest(TestCase):
             if "META-INF/MANIFEST.MF" not in entries:
                 self.fail("No META-INF/MANIFEST.MF in just created JAR\n"
                           "JAR content:\n%s" % ", ".join(entries))
-            mf.parse(jar_file.read("META-INF/MANIFEST.MF"))
+
+            mf.load_from_jar(jar_fn)
 
         rmtree(tmp_dir)
 

--- a/tests/manifest.py
+++ b/tests/manifest.py
@@ -85,7 +85,7 @@ class ManifestTest(TestCase):
         mf.parse_file(src_file)
         result = mf.get_data()
 
-        self.assertEquals(
+        self.assertEqual(
             result, expected_result,
             "Manifest load/store does not match with file %s. Received:\n%s"
             % (src_file, result))


### PR DESCRIPTION
JAR manifest (and signature file, which is a kind of manifest) is, according to the [Oracle spec](https://docs.oracle.com/javase/8/docs/technotes/guides/jar/jar.html#JAR_Manifest), unicode text, serialized in UTF-8 encoding. Previously python-javatools stored manifest as `str`, and there were no tests for manifests containing non-ASCII characters. (In manifests, non-ASCII can appear in file names.)

This PR changes internal representation of the manifest to Unicode. It fixes the item _"Jar manifest and signature file are UTF-8 encoded texts"_ from the list at https://github.com/obriencj/python-javatools/pull/89#issuecomment-428266618

This PR does not yet intentionally change code to make Python 3 work any better, but as a coincidence three more tests start passing under Py3: `JardiffTest.test_sig_manifest_tampered`, `ManifestTest.test_cli_verify_nok` and `ManifestTest.test_cli_verify_ok`.