### PR TITLE
Completed support for Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ script: python setup.py test
 
 python:
   - "2.7"
-  # - "3.5"
-  # - "3.6"
+  - "3.5"
+  - "3.6"
 
 # needs this for travis to support 3.7
 # matrix:

--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ heck, just fork it!
 
 ## Requirements
 
-* [Python] 2.6 or later (no support for Python 3)
+* [Python] 2.7, 3.5 or 3.6
 * [Setuptools]
-* [Cheetah] is used in the generation of HTML reports
+* [Cheetah3] is used in the generation of HTML reports
 * [M2Crypto] is used for cryptographic operations
 
 In addition, the following tools are used in building and testing the

--- a/javatools/manifest.py
+++ b/javatools/manifest.py
@@ -235,6 +235,10 @@ class ManifestSection(OrderedDict):
         self[self.primary_key] = name
 
 
+    def __gt__(self, other_section):
+        # we need just some ordering, no matter which.
+        return self.get_data() > other_section.get_data()
+
     def __setitem__(self, k, v):
         # pylint: disable=W0221
         # we want the behavior of OrderedDict, but don't take the

--- a/javatools/report.py
+++ b/javatools/report.py
@@ -387,13 +387,14 @@ def _indent_change(change, out, options, indent):
 
 def _indent(stream, indent, *msgs):
 
-    """ write a message to stream, with indentation. Also ensures that
+    """ write a message to a text stream, with indentation. Also ensures that
     the output encoding of the messages is safe for writing. """
 
     for x in range(0, indent):
         stream.write("  ")
     for x in msgs:
-        stream.write(x.encode("ascii", "backslashreplace"))
+        # Any nicer way? In Py2 x can be 'str' or 'unicode'.
+        stream.write(x.encode("ascii", "backslashreplace").decode("ascii"))
     stream.write("\n")
 
 

--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,7 @@ setup(name = "javatools",
 
       python_requires = (
           ">=2.7, "
-          # "!=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, "
+          "!=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, "
           "<4"
       ),
 
@@ -94,8 +94,8 @@ setup(name = "javatools",
           "Intended Audience :: Developers",
           "Intended Audience :: Information Technology",
           "Programming Language :: Python :: 2.7",
-          # "Programming Language :: Python :: 3.5",
-          # "Programming Language :: Python :: 3.6",
+          "Programming Language :: Python :: 3.5",
+          "Programming Language :: Python :: 3.6",
           # "Programming Language :: Python :: 3.7",
           "Topic :: Software Development :: Disassemblers",
       ],

--- a/tests/manifest.py
+++ b/tests/manifest.py
@@ -39,7 +39,7 @@ class ManifestTest(TestCase):
         """
 
         # the result we expect to see from running the script
-        with open(get_data_fn(expected_result)) as f:
+        with open(get_data_fn(expected_result), mode="rb") as f:
             expected_result = f.read()
 
         # the invocation of the script
@@ -77,7 +77,7 @@ class ManifestTest(TestCase):
 
         # the expected result is identical to what we feed into the
         # manifest parser
-        with open(src_file) as f:
+        with open(src_file, mode='rb') as f:
             expected_result = f.read()
 
         # create a manifest and parse the chosen test data


### PR DESCRIPTION
This PR finishes Py3 support. While the merged #94 handled "incoming" text/binary data conversions, this one handles "outgoing".

Differently from what I proposed previously in #89 , this PR does not reduce function interfaces not to handle streams. This results in much smaller changes to the existing code.

Closes #53.