### PR TITLE
Put "cheetah_cmd.py" to the distribution

### DIFF
--- a/extras/cheetah_cmd.py
+++ b/extras/cheetah_cmd.py
@@ -30,7 +30,7 @@ from os import makedirs
 from os.path import basename, exists, join, splitext
 
 
-DEFAULT_CONFIG = "extras/cheetah.cfg"
+DEFAULT_CONFIG = "cheetah.cfg"
 
 
 class cheetah_cmd(Command):

--- a/setup.py
+++ b/setup.py
@@ -24,13 +24,14 @@ license: LGPL v.3
 
 
 from setuptools import setup
-from cheetah_cmd import cheetah_build_py_cmd
+from extras.cheetah_cmd import cheetah_build_py_cmd
 
 
 setup(name = "javatools",
       version = "1.5.0",
 
       packages = [
+          "extras",
           "javatools",
           "javatools.cheetah",
       ],


### PR DESCRIPTION
"cheetah_cmd.py" is required for "setup.py" to run, but it does not belong
to any package, thus not getting into the distribution.

Return it to its previous location "extras".

Closes #100 .