### PR TITLE
Formatting cleanup inspired by flake8

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,13 +15,13 @@
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-#sys.path.insert(0, os.path.abspath('.'))
-#sys.path.insert(0, os.path.abspath('../'))
+# sys.path.insert(0, os.path.abspath('.'))
+# sys.path.insert(0, os.path.abspath('../'))
 
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
-#needs_sphinx = '1.0'
+# needs_sphinx = '1.0'
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
@@ -44,7 +44,7 @@ templates_path = ['_templates']
 source_suffix = '.rst'
 
 # The encoding of source files.
-#source_encoding = 'utf-8-sig'
+# source_encoding = 'utf-8-sig'
 
 # The master toctree document.
 master_doc = 'index'
@@ -68,9 +68,9 @@ language = 'English'
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:
-#today = ''
+# today = ''
 # Else, today_fmt is used as the format for a strftime call.
-#today_fmt = '%B %d, %Y'
+# today_fmt = '%B %d, %Y'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -78,27 +78,27 @@ exclude_patterns = ['_build']
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.
-#default_role = None
+# default_role = None
 
 # If true, '()' will be appended to :func: etc. cross-reference text.
 add_function_parentheses = True
 
 # If true, the current module name will be prepended to all description
 # unit titles (such as .. function::).
-#add_module_names = True
+# add_module_names = True
 
 # If true, sectionauthor and moduleauthor directives will be shown in the
 # output. They are ignored by default.
-#show_authors = False
+# show_authors = False
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'sphinx'
 
 # A list of ignored prefixes for module index sorting.
-#modindex_common_prefix = []
+# modindex_common_prefix = []
 
 # If true, keep warnings as "system message" paragraphs in the built documents.
-#keep_warnings = False
+# keep_warnings = False
 
 
 # -- Options for HTML output ----------------------------------------------
@@ -110,26 +110,26 @@ html_theme = 'default'
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
-#html_theme_options = {}
+# html_theme_options = {}
 
 # Add any paths that contain custom themes here, relative to this directory.
-#html_theme_path = []
+# html_theme_path = []
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".
-#html_title = None
+# html_title = None
 
 # A shorter title for the navigation bar.  Default is the same as html_title.
-#html_short_title = None
+# html_short_title = None
 
 # The name of an image file (relative to this directory) to place at the top
 # of the sidebar.
-#html_logo = None
+# html_logo = None
 
 # The name of an image file (within the static path) to use as favicon of the
 # docs.  This file should be a Windows icon file (.ico) being 16x16 or 32x32
 # pixels large.
-#html_favicon = None
+# html_favicon = None
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
@@ -139,22 +139,22 @@ html_static_path = []
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied
 # directly to the root of the documentation.
-#html_extra_path = []
+# html_extra_path = []
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.
-#html_last_updated_fmt = '%b %d, %Y'
+# html_last_updated_fmt = '%b %d, %Y'
 
 # If true, SmartyPants will be used to convert quotes and dashes to
 # typographically correct entities.
-#html_use_smartypants = True
+# html_use_smartypants = True
 
 # Custom sidebar templates, maps document names to template names.
-#html_sidebars = {}
+# html_sidebars = {}
 
 # Additional templates that should be rendered to pages, maps page names to
 # template names.
-#html_additional_pages = {}
+# html_additional_pages = {}
 
 # If false, no module index is generated.
 html_domain_indices = True
@@ -163,24 +163,24 @@ html_domain_indices = True
 html_use_index = True
 
 # If true, the index is split into individual pages for each letter.
-#html_split_index = False
+# html_split_index = False
 
 # If true, links to the reST sources are added to the pages.
-#html_show_sourcelink = True
+# html_show_sourcelink = True
 
 # If true, "Created using Sphinx" is shown in the HTML footer. Default is True.
-#html_show_sphinx = True
+# html_show_sphinx = True
 
 # If true, "(C) Copyright ..." is shown in the HTML footer. Default is True.
-#html_show_copyright = True
+# html_show_copyright = True
 
 # If true, an OpenSearch description file will be output, and all pages will
 # contain a <link> tag referring to it.  The value of this option must be the
 # base URL from which the finished HTML is served.
-#html_use_opensearch = ''
+# html_use_opensearch = ''
 
 # This is the file name suffix for HTML files (e.g. ".xhtml").
-#html_file_suffix = None
+# html_file_suffix = None
 
 # Output file base name for HTML help builder.
 htmlhelp_basename = 'javatoolsdoc'
@@ -189,43 +189,43 @@ htmlhelp_basename = 'javatoolsdoc'
 # -- Options for LaTeX output ---------------------------------------------
 
 latex_elements = {
-# The paper size ('letterpaper' or 'a4paper').
-#'papersize': 'letterpaper',
+    # The paper size ('letterpaper' or 'a4paper').
+    # 'papersize': 'letterpaper',
 
-# The font size ('10pt', '11pt' or '12pt').
-#'pointsize': '10pt',
+    # The font size ('10pt', '11pt' or '12pt').
+    # 'pointsize': '10pt',
 
-# Additional stuff for the LaTeX preamble.
-#'preamble': '',
+    # Additional stuff for the LaTeX preamble.
+    # 'preamble': '',
 }
 
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-  ('index', 'javatools.tex', u'javatools Documentation',
-   u"Christopher O'Brien", 'manual'),
+    ('index', 'javatools.tex', u'javatools Documentation',
+     u"Christopher O'Brien", 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
 # the title page.
-#latex_logo = None
+# latex_logo = None
 
 # For "manual" documents, if this is true, then toplevel headings are parts,
 # not chapters.
-#latex_use_parts = False
+# latex_use_parts = False
 
 # If true, show page references after internal links.
-#latex_show_pagerefs = False
+# latex_show_pagerefs = False
 
 # If true, show URL addresses after external links.
-#latex_show_urls = False
+# latex_show_urls = False
 
 # Documents to append as an appendix to all manuals.
-#latex_appendices = []
+# latex_appendices = []
 
 # If false, no module index is generated.
-#latex_domain_indices = True
+# latex_domain_indices = True
 
 
 # -- Options for manual page output ---------------------------------------
@@ -238,7 +238,7 @@ man_pages = [
 ]
 
 # If true, show URL addresses after external links.
-#man_show_urls = False
+# man_show_urls = False
 
 
 # -- Options for Texinfo output -------------------------------------------
@@ -247,23 +247,23 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-  ('index', 'javatools', u'javatools Documentation',
-   u"Christopher O'Brien", 'javatools',
-   'Python utilities for investigating Java class files',
-   'Miscellaneous'),
+    ('index', 'javatools', u'javatools Documentation',
+     u"Christopher O'Brien", 'javatools',
+     'Python utilities for investigating Java class files',
+     'Miscellaneous'),
 ]
 
 # Documents to append as an appendix to all manuals.
-#texinfo_appendices = []
+# texinfo_appendices = []
 
 # If false, no module index is generated.
-#texinfo_domain_indices = True
+# texinfo_domain_indices = True
 
 # How to display URL addresses: 'footnote', 'no', or 'inline'.
-#texinfo_show_urls = 'footnote'
+# texinfo_show_urls = 'footnote'
 
 # If true, do not generate a @detailmenu in the "Top" node's menu.
-#texinfo_no_detailmenu = False
+# texinfo_no_detailmenu = False
 
 
 # -- Options for Epub output ----------------------------------------------
@@ -275,65 +275,65 @@ epub_publisher = u"Christopher O'Brien"
 epub_copyright = u"2014, Christopher O'Brien"
 
 # The basename for the epub file. It defaults to the project name.
-#epub_basename = u'javatools'
+# epub_basename = u'javatools'
 
-# The HTML theme for the epub output. Since the default themes are not optimized
-# for small screen space, using the same theme for HTML and epub output is
-# usually not wise. This defaults to 'epub', a theme designed to save visual
-# space.
-#epub_theme = 'epub'
+# The HTML theme for the epub output. Since the default themes are not
+# optimized for small screen space, using the same theme for HTML and epub
+# output is usually not wise. This defaults to 'epub', a theme designed
+# to save visual space.
+# epub_theme = 'epub'
 
 # The language of the text. It defaults to the language option
 # or en if the language is not set.
-#epub_language = ''
+# epub_language = ''
 
 # The scheme of the identifier. Typical schemes are ISBN or URL.
-#epub_scheme = ''
+# epub_scheme = ''
 
 # The unique identifier of the text. This can be a ISBN number
 # or the project homepage.
-#epub_identifier = ''
+# epub_identifier = ''
 
 # A unique identification for the text.
-#epub_uid = ''
+# epub_uid = ''
 
 # A tuple containing the cover image and cover page html template filenames.
-#epub_cover = ()
+# epub_cover = ()
 
 # A sequence of (type, uri, title) tuples for the guide element of content.opf.
-#epub_guide = ()
+# epub_guide = ()
 
 # HTML files that should be inserted before the pages created by sphinx.
 # The format is a list of tuples containing the path and title.
-#epub_pre_files = []
+# epub_pre_files = []
 
 # HTML files shat should be inserted after the pages created by sphinx.
 # The format is a list of tuples containing the path and title.
-#epub_post_files = []
+# epub_post_files = []
 
 # A list of files that should not be packed into the epub file.
 epub_exclude_files = ['search.html']
 
 # The depth of the table of contents in toc.ncx.
-#epub_tocdepth = 3
+# epub_tocdepth = 3
 
 # Allow duplicate toc entries.
-#epub_tocdup = True
+# epub_tocdup = True
 
 # Choose between 'default' and 'includehidden'.
-#epub_tocscope = 'default'
+# epub_tocscope = 'default'
 
 # Fix unsupported image types using the PIL.
-#epub_fix_images = False
+# epub_fix_images = False
 
 # Scale large images.
-#epub_max_image_width = 0
+# epub_max_image_width = 0
 
 # How to display URL addresses: 'footnote', 'no', or 'inline'.
-#epub_show_urls = 'inline'
+# epub_show_urls = 'inline'
 
 # If false, no index is generated.
-#epub_use_index = True
+# epub_use_index = True
 
 # autoclass_content = 'both'
 

--- a/javatools/__init__.py
+++ b/javatools/__init__.py
@@ -2100,7 +2100,7 @@ def _pretty_const_type_val(typecode, val):
 
     if typecode == CONST_Utf8:
         typestr = "Utf8"  # formerly Asciz, which was considered Java bug
-        if not isinstance(val, str):	# Py2, val is 'unicode'
+        if not isinstance(val, str):  # Py2, val is 'unicode'
             val = repr(val)[2:-1]  # trim off the surrounding u"" (HACK)
         else:
             val = repr(val)[1:-1]  # trim off the surrounding "" (HACK)
@@ -2180,11 +2180,11 @@ def _next_argsig(s):
 
     elif c == "[":
         d, s = _next_argsig(s[1:])
-        result = (c + d, s[len(d)+1:])
+        result = (c + d, s[len(d) + 1:])
 
     elif c == "L":
         i = s.find(';') + 1
-        result = (s[:i], s[i+1:])
+        result = (s[:i], s[i + 1:])
 
     elif c == "(":
         i = s.find(')') + 1

--- a/javatools/cheetah/setuptools.py
+++ b/javatools/cheetah/setuptools.py
@@ -109,7 +109,7 @@ class cheetah_build_py_cmd(build_py):
         comp.addModuleHeader("pylint: disable=C,W,R,F")
 
         outfd = join(self.build_lib, *package.split("."))
-        outfn = join(outfd, template+".py")
+        outfn = join(outfd, template + ".py")
 
         if not exists(outfd):
             makedirs(outfd)
@@ -128,7 +128,7 @@ class cheetah_build_py_cmd(build_py):
             templates = self.find_package_templates(package, package_dir)
             for _, template, _ in templates:
                 outfd = join(self.build_lib, *package.split("."))
-                outfn = join(outfd, template+".py")
+                outfn = join(outfd, template + ".py")
 
                 built.append(outfn)
 

--- a/javatools/classdiff.py
+++ b/javatools/classdiff.py
@@ -985,27 +985,31 @@ def add_classdiff_optgroup(parser):
 
     g = parser.add_argument_group("Class Checking Options")
 
-    g.add_argument("--ignore-version-up", action="store_true", default=False)
+    g.add_argument("--ignore-version-up", action="store_true",
+                   default=False)
     g.add_argument("--ignore-version-down", action="store_true", default=False)
     g.add_argument("--ignore-platform-up", action="store_true", default=False)
-    g.add_argument("--ignore-platform-down", action="store_true", default=False)
-    g.add_argument("--ignore-absolute-lines", action="store_true", default=False)
-    g.add_argument("--ignore-relative-lines", action="store_true", default=False)
+    g.add_argument("--ignore-platform-down", action="store_true",
+                   default=False)
+    g.add_argument("--ignore-absolute-lines", action="store_true",
+                   default=False)
+    g.add_argument("--ignore-relative-lines", action="store_true",
+                   default=False)
     g.add_argument("--ignore-deprecated", action="store_true", default=False)
     g.add_argument("--ignore-added", action="store_true", default=False)
     g.add_argument("--ignore-pool", action="store_true", default=False)
 
     g.add_argument("--ignore-lines", nargs=0,
-                 help="ignore relative and absolute line-number changes",
-                 action=_opt_cb_ign_lines)
+                   help="ignore relative and absolute line-number changes",
+                   action=_opt_cb_ign_lines)
 
     g.add_argument("--ignore-platform", nargs=0,
-                 help="ignore platform changes",
-                 action=_opt_cb_ign_platform)
+                   help="ignore platform changes",
+                   action=_opt_cb_ign_platform)
 
     g.add_argument("--ignore-version", nargs=0,
-                 help="ignore version changes",
-                 action=_opt_cb_ign_version)
+                   help="ignore version changes",
+                   action=_opt_cb_ign_version)
 
 
 class _opt_cb_ignore(Action):
@@ -1084,20 +1088,20 @@ def add_general_optgroup(parser):
     g = parser.add_argument_group("General Options")
 
     g.add_argument("-q", "--quiet", dest="silent",
-                 action="store_true", default=False)
+                   action="store_true", default=False)
 
     g.add_argument("-v", "--verbose", nargs=0, action=_opt_cb_verbose)
 
     g.add_argument("-o", "--output", dest="output", default=None)
 
     g.add_argument("-j", "--json", dest="json",
-                 action="store_true", default=False)
+                   action="store_true", default=False)
 
     g.add_argument("--show-ignored", action="store_true", default=False)
     g.add_argument("--show-unchanged", action="store_true", default=False)
 
     g.add_argument("--ignore", action=_opt_cb_ignore,
-                 help="comma-separated list of ignores")
+                   help="comma-separated list of ignores")
 
 
 def create_optparser(progname=None):

--- a/javatools/classinfo.py
+++ b/javatools/classinfo.py
@@ -412,51 +412,52 @@ def add_classinfo_optgroup(parser):
     g = parser.add_argument_group("Class Info Options")
 
     g.add_argument("--class-provides", dest="class_provides",
-                 action="store_true", default=False,
-                 help="API provides information at the class level")
+                   action="store_true", default=False,
+                   help="API provides information at the class level")
 
     g.add_argument("--class-requires", dest="class_requires",
-                 action="store_true", default=False,
-                 help="API requires information at the class level")
+                   action="store_true", default=False,
+                   help="API requires information at the class level")
 
     g.add_argument("--api-ignore", dest="api_ignore",
-                 action="append", default=list(),
-                 help="globs of packages to not print in provides"
-                 " or requires modes")
+                   action="append", default=list(),
+                   help="globs of packages to not print in provides"
+                   " or requires modes")
 
     g.add_argument("--header", dest="show",
-                 action="store_const", default=SHOW_PUBLIC, const=SHOW_HEADER,
-                 help="show just the class header, no members")
+                   action="store_const", default=SHOW_PUBLIC,
+                   const=SHOW_HEADER,
+                   help="show just the class header, no members")
 
     g.add_argument("--public", dest="show",
-                 action="store_const", const=SHOW_PUBLIC,
-                 help="show only public members")
+                   action="store_const", const=SHOW_PUBLIC,
+                   help="show only public members")
 
     g.add_argument("--package", dest="show",
-                 action="store_const", const=SHOW_PACKAGE,
-                 help="show public and protected members")
+                   action="store_const", const=SHOW_PACKAGE,
+                   help="show public and protected members")
 
     g.add_argument("--private", dest="show",
-                 action="store_const", const=SHOW_PRIVATE,
-                 help="show all members")
+                   action="store_const", const=SHOW_PRIVATE,
+                   help="show all members")
 
     g.add_argument("-l", dest="lines", action="store_true",
-                 help="show the line number table")
+                   help="show the line number table")
 
     g.add_argument("-o", dest="locals", action="store_true",
-                 help="show the local variable tables")
+                   help="show the local variable tables")
 
     g.add_argument("-c", dest="disassemble", action="store_true",
-                 help="disassemble method code")
+                   help="disassemble method code")
 
     g.add_argument("-s", dest="sigs", action="store_true",
-                 help="show internal type signatures")
+                   help="show internal type signatures")
 
     g.add_argument("-p", dest="constpool", action="store_true",
-                 help="show the constants pool")
+                   help="show the constants pool")
 
     g.add_argument("--verbose", dest="verbose", action="store_true",
-                 help="sets -locsp options and shows stack bounds")
+                   help="sets -locsp options and shows stack bounds")
 
 
 def create_optparser(progname):
@@ -464,7 +465,7 @@ def create_optparser(progname):
     parser.add_argument("classfile", nargs="+",
                         help="Java class file(s) to inspect")
     parser.add_argument("--json", action="store_true", default=False,
-                      help="output JSON")
+                        help="output JSON")
 
     add_classinfo_optgroup(parser)
 

--- a/javatools/distdiff.py
+++ b/javatools/distdiff.py
@@ -599,22 +599,22 @@ def add_distdiff_optgroup(parser):
     og = parser.add_argument_group("Distribution Checking Options")
 
     og.add_argument("--processes", type=int, default=cpus,
-                  help="Number of child processes to spawn to handle"
-                  " sub-reports. Set to 0 to disable multi-processing."
-                  " Defaults to the number of CPUs (%r)" % cpus)
+                    help="Number of child processes to spawn to handle"
+                    " sub-reports. Set to 0 to disable multi-processing."
+                    " Defaults to the number of CPUs (%r)" % cpus)
 
     og.add_argument("--shallow", action="store_true", default=False,
-                  help="Check only that the files of this dist have"
-                  "changed, do not infer the meaning")
+                    help="Check only that the files of this dist have"
+                    "changed, do not infer the meaning")
 
     og.add_argument("--ignore-filenames", action="append", default=[],
-                  help="file glob to ignore. Can be specified multiple"
-                  " times")
+                    help="file glob to ignore. Can be specified multiple"
+                    " times")
 
     og.add_argument("--ignore-trailing-whitespace",
-                  action="store_true", default=False,
-                  help="ignore trailing whitespace when comparing text"
-                  " files")
+                    action="store_true", default=False,
+                    help="ignore trailing whitespace when comparing text"
+                    " files")
 
 
 def create_optparser(progname=None):

--- a/javatools/distinfo.py
+++ b/javatools/distinfo.py
@@ -259,12 +259,12 @@ def add_distinfo_optgroup(parser):
     g = parser.add_argument_group("Distribution Info Options")
 
     g.add_argument("--dist-provides", dest="dist_provides",
-                 action="store_true", default=False,
-                 help="API provides information at the distribution level")
+                   action="store_true", default=False,
+                   help="API provides information at the distribution level")
 
     g.add_argument("--dist-requires", dest="dist_requires",
-                 action="store_true", default=False,
-                 help="API requires information at the distribution level")
+                   action="store_true", default=False,
+                   help="API requires information at the distribution level")
 
 
 def create_optparser(progname):
@@ -274,7 +274,7 @@ def create_optparser(progname):
     parser = ArgumentParser(prog=progname)
     parser.add_argument("dist", help="distribution to inspect")
     parser.add_argument("--json", dest="json", action="store_true",
-                      help="output in JSON mode")
+                        help="output in JSON mode")
 
     add_distinfo_optgroup(parser)
     add_jarinfo_optgroup(parser)

--- a/javatools/jardiff.py
+++ b/javatools/jardiff.py
@@ -561,20 +561,20 @@ def add_jardiff_optgroup(parser):
     og.add_argument("--ignore-jar-entry", action="append", default=[])
 
     og.add_argument("--ignore-jar-signature",
-                  action="store_true", default=False,
-                  help="Ignore JAR signing changes")
+                    action="store_true", default=False,
+                    help="Ignore JAR signing changes")
 
     og.add_argument("--ignore-manifest",
-                  action="store_true", default=False,
-                  help="Ignore changes to manifests")
+                    action="store_true", default=False,
+                    help="Ignore changes to manifests")
 
     og.add_argument("--ignore-manifest-subsections",
-                  action="store_true", default=False,
-                  help="Ignore changes to manifest subsections")
+                    action="store_true", default=False,
+                    help="Ignore changes to manifest subsections")
 
     og.add_argument("--ignore-manifest-key",
-                  action="append", default=[],
-                  help="case-insensitive manifest keys to ignore")
+                    action="append", default=[],
+                    help="case-insensitive manifest keys to ignore")
 
 
 def create_optparser(progname=None):

--- a/javatools/jarinfo.py
+++ b/javatools/jarinfo.py
@@ -295,21 +295,21 @@ def add_jarinfo_optgroup(parser):
     g = parser.add_argument_group("JAR Info Options")
 
     g.add_argument("--zip", action="store_true", default=False,
-                 help="print zip information")
+                   help="print zip information")
 
     g.add_argument("--manifest", action="store_true", default=False,
-                 help="print manifest information")
+                   help="print manifest information")
 
     g.add_argument("--jar-classes", action="store_true", default=False,
-                 help="print information about contained classes")
+                   help="print information about contained classes")
 
     g.add_argument("--jar-provides", dest="jar_provides",
-                 action="store_true", default=False,
-                 help="API provides information at the JAR level")
+                   action="store_true", default=False,
+                   help="API provides information at the JAR level")
 
     g.add_argument("--jar-requires", dest="jar_requires",
-                 action="store_true", default=False,
-                 help="API requires information at the JAR level")
+                   action="store_true", default=False,
+                   help="API requires information at the JAR level")
 
 
 def create_optparser(progname):
@@ -318,7 +318,7 @@ def create_optparser(progname):
     parser.add_argument("jarfiles", nargs="+",
                         help="JAR files to inspect")
     parser.add_argument("--json", dest="json", action="store_true",
-                      help="output in JSON mode")
+                        help="output in JSON mode")
     add_jarinfo_optgroup(parser)
     add_classinfo_optgroup(parser)
 

--- a/javatools/jarutil.py
+++ b/javatools/jarutil.py
@@ -277,7 +277,8 @@ def cli_sign_jar(argument_list=None):
     parser.add_argument("key_alias", type=str,
                         help="JAR \"key alias\" to use")
 
-    parser.add_argument("-d", "--digest", action="store", default="SHA-256",  # TODO: factor to a constant
+    parser.add_argument("-d", "--digest", action="store", default="SHA-256",
+                        # TODO: factor to a constant
                         help="Digest algorithm used for signing")
 
     parser.add_argument("-c", "--chain", action="append",

--- a/javatools/manifest.py
+++ b/javatools/manifest.py
@@ -106,7 +106,8 @@ def _get_digest(java_name, as_string=False):
             else JAVA_TO_OPENSSL_DIGESTS[java_name]
     except KeyError:
         raise UnsupportedDigest("Unsupported digest %s. Supported: %s" %
-                                (java_name, ", ".join(sorted(JAVA_TO_OPENSSL_DIGESTS.keys()))))
+                                (java_name, ", ".join(sorted(
+                                 JAVA_TO_OPENSSL_DIGESTS.keys()))))
 
 
 # Note 1: Java supports also MD2, but hashlib does not

--- a/javatools/report.py
+++ b/javatools/report.py
@@ -269,7 +269,7 @@ def add_general_report_optgroup(parser):
     g.add_argument("--report-dir", action="store", default=None)
 
     g.add_argument("--report", action=_opt_cb_report,
-                 help="comma-separated list of report formats")
+                   help="comma-separated list of report formats")
 
 
 class JSONReportFormat(ReportFormat):
@@ -614,14 +614,14 @@ def add_html_report_optgroup(parser):
     g = parser.add_argument_group("HTML Report Options")
 
     g.add_argument("--html-stylesheet", action="append",
-                 dest="html_stylesheets", default=list())
+                   dest="html_stylesheets", default=list())
 
     g.add_argument("--html-javascript", action="append",
-                 dest="html_javascripts", default=list())
+                   dest="html_javascripts", default=list())
 
     g.add_argument("--html-copy-data", action="store", default=None,
-                 help="Copy default resources to the given directory and"
-                 " enable them in the template")
+                   help="Copy default resources to the given directory and"
+                   " enable them in the template")
 
 
 def quick_report(report_type, change, options):


### PR DESCRIPTION
No executable code change, formatting/whitespace cleanup only:

* Amount of `flake8` reported errors reduced from 98 to 21
* Some other PEP8 whitespace styling 

Thanks to @tehw0lf for this.