### PR TITLE
Improve fail-proof ness

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -14,3 +14,6 @@ https://github.com/rumpeltux
 
 Brian J Murray <bmurray7jhu@gmail.com>
 https://github.com/bmurray7/
+
+Matus Jasnicky
+https://github.com/Matmaus

--- a/javatools/__init__.py
+++ b/javatools/__init__.py
@@ -2245,6 +2245,14 @@ def _next_argsig(s):
         i = s.find(')') + 1
         result = (s[:i], s[i:])
 
+    # Some files may be corrupted and contain bad argument signature (c = '.').
+    # We do not want to fail on them rather skip this argument signature,
+    # continue and finish successfully.
+    # Example:
+    # s = '[Lcom.sun.glass.ui.EventLoop$State;.clone():java.lang.Object'
+    elif c == ".":
+        result = (s[1:], "")
+
     else:
         raise Unimplemented("_next_argsig is %r in %r" % (c, s))
 

--- a/javatools/__init__.py
+++ b/javatools/__init__.py
@@ -160,6 +160,14 @@ class ClassUnpackException(Exception):
     pass
 
 
+class UnknownConstantPoolTag(Exception):
+    """
+    raised when a constant pool tag is unknown and probably corrupted
+    """
+
+    pass
+
+
 class JavaConstantPool(object):
     """
     A constants pool
@@ -2138,7 +2146,7 @@ def _unpack_const_item(unpacker):
         val = unpacker.unpack_struct(_H)
 
     else:
-        raise Unimplemented("unknown constant type %r" % typecode)
+        raise UnknownConstantPoolTag("unknown constant type %r" % typecode)
 
     return typecode, val
 

--- a/javatools/__init__.py
+++ b/javatools/__init__.py
@@ -2085,7 +2085,8 @@ def _unpack_const_item(unpacker):
             val = val.decode("utf8")
         except UnicodeDecodeError:
             # easiest hack to handle java's modified utf-8 encoding
-            val = val.replace(b"\xC0\x80", b"\x00").decode("utf8")
+            # also we want at least some data, thus we ignore unknown characters
+            val = val.replace(b"\xC0\x80", b"\x00").decode("utf8", errors="ignore")
 
     elif typecode == CONST_Integer:
         (val,) = unpacker.unpack(">i")

--- a/javatools/__init__.py
+++ b/javatools/__init__.py
@@ -294,7 +294,7 @@ class JavaConstantPool(object):
             return (v[0], self.deref_const(v[1]))
 
         else:
-            raise Unimplemented("Unknown constant pool type %r" % t)
+            raise UnknownConstantPoolTagException("Unknown constant pool type %r" % t)
 
 
     def constants(self):
@@ -408,7 +408,7 @@ class JavaConstantPool(object):
             result = ""
 
         else:
-            raise Unimplemented("No pretty for const type %r" % t)
+            raise UnknownConstantPoolTagException("No pretty for const type %r" % t)
 
         return result
 
@@ -2217,7 +2217,7 @@ def _pretty_const_type_val(typecode, val):
     elif typecode == CONST_Package:
         typestr = "Package"
     else:
-        raise Unimplemented("unknown constant type %r" % typecode)
+        raise UnknownConstantPoolTagException("unknown constant type %r" % typecode)
 
     return typestr, val
 

--- a/javatools/__init__.py
+++ b/javatools/__init__.py
@@ -236,23 +236,52 @@ class JavaConstantPool(object):
 
         t, v = self.consts[index]
 
+        # CONSTANT_info {
+        #     u1 tag;
+        #     u4 bytes; (the value of the constant)
+        # }
+        # NOTE: Long and Double has high_bytes and low_bytes.
+        # NOTE: Utf8 has two fields length and bytes
         if t in (CONST_Utf8, CONST_Integer, CONST_Float,
                  CONST_Long, CONST_Double):
             return v
 
+        # CONSTANT_info {
+        #     u1 tag;
+        #     u2 index; (valid index into the constant_pool)
+        # }
+        # NOTE: each constant can have a little bit different field name
         elif t in (CONST_Class, CONST_String, CONST_MethodType, CONST_Module, CONST_Package):
             return self.deref_const(v)
 
+        # CONSTANT_info {
+        #     u1 tag;
+        #     u2 index; (valid index into the constant_pool)
+        #     u2 additional_index; (valid index into the constant_pool)
+        # }
+        # NOTE: each constant can have a little bit different field name
         elif t in (CONST_Fieldref, CONST_Methodref,
                    CONST_InterfaceMethodref, CONST_NameAndType,
                    CONST_ModuleId):
             return tuple(self.deref_const(i) for i in v)
 
+        # CONSTANT_info {
+        #     u1 tag;
+        #     u2 bootstrap_method_attr_index; (must be a valid index into the bootstrap_methods array
+        #                                      of the bootstrap method table of this class file)
+        #     u2 name_and_type_index; (valid index into the constant_pool)
+        # }
         elif t in (CONST_InvokeDynamic, CONST_Dynamic):
             # TODO: v[0] needs to come from the bootstrap methods table
             return (v[0], self.deref_const(v[1]))
 
+        # CONSTANT_info {
+        #     u1 tag;
+        #     u1 reference_kind; (must be in the range 1 to 9)
+        #     u2 reference_index; (valid index into the constant_pool)
+        # }
         elif t == CONST_MethodHandle:
+            # TODO: v[0] treat index according to its kind
             return (v[0], self.deref_const(v[1]))
 
         else:

--- a/javatools/__init__.py
+++ b/javatools/__init__.py
@@ -90,9 +90,9 @@ CONST_Methodref = 10
 CONST_InterfaceMethodref = 11
 CONST_NameAndType = 12
 CONST_ModuleId = 13  # Removed? Maybe OpenJDK only?
-CONST_MethodHandle = 15  # TODO
-CONST_MethodType = 16  # TODO
-CONST_InvokeDynamic = 18  # TODO
+CONST_MethodHandle = 15
+CONST_MethodType = 16
+CONST_InvokeDynamic = 18
 CONST_Module = 19
 CONST_Package = 20
 
@@ -250,6 +250,16 @@ class JavaConstantPool(object):
         elif t == CONST_InvokeDynamic:
             # TODO: v[0] needs to come from the bootstrap methods table
             return (v[0], self.deref_const(v[1]))
+
+        elif t == CONST_MethodHandle:
+            return (v[0], self.deref_const(v[1]))
+
+        elif t == CONST_MethodType:
+            return self.deref_const(v[0])
+
+        elif t == CONST_InvokeDynamic:
+            #TODO: v[0] is an index to an element in the bootstrap_methods array of the bootstrap method table
+            return self.deref_const(v[1])
 
         else:
             raise Unimplemented("Unknown constant pool type %r" % t)

--- a/javatools/__init__.py
+++ b/javatools/__init__.py
@@ -92,7 +92,7 @@ CONST_NameAndType = 12
 CONST_ModuleId = 13  # Removed? Maybe OpenJDK only?
 CONST_MethodHandle = 15
 CONST_MethodType = 16
-CONST_Dynamic = 17 # TODO not implemented
+CONST_Dynamic = 17
 CONST_InvokeDynamic = 18
 CONST_Module = 19
 CONST_Package = 20
@@ -248,7 +248,7 @@ class JavaConstantPool(object):
                    CONST_ModuleId):
             return tuple(self.deref_const(i) for i in v)
 
-        elif t == CONST_InvokeDynamic:
+        elif t in (CONST_InvokeDynamic, CONST_Dynamic):
             # TODO: v[0] needs to come from the bootstrap methods table
             return (v[0], self.deref_const(v[1]))
 

--- a/javatools/__init__.py
+++ b/javatools/__init__.py
@@ -240,12 +240,12 @@ class JavaConstantPool(object):
                  CONST_Long, CONST_Double):
             return v
 
-        elif t in (CONST_Class, CONST_String, CONST_MethodType):
+        elif t in (CONST_Class, CONST_String, CONST_MethodType, CONST_Module, CONST_Package):
             return self.deref_const(v)
 
         elif t in (CONST_Fieldref, CONST_Methodref,
                    CONST_InterfaceMethodref, CONST_NameAndType,
-                   CONST_ModuleId, CONST_Module, CONST_Package):
+                   CONST_ModuleId):
             return tuple(self.deref_const(i) for i in v)
 
         elif t == CONST_InvokeDynamic:

--- a/javatools/__init__.py
+++ b/javatools/__init__.py
@@ -92,6 +92,7 @@ CONST_NameAndType = 12
 CONST_ModuleId = 13  # Removed? Maybe OpenJDK only?
 CONST_MethodHandle = 15
 CONST_MethodType = 16
+CONST_Dynamic = 17 # TODO not implemented
 CONST_InvokeDynamic = 18
 CONST_Module = 19
 CONST_Package = 20

--- a/javatools/__init__.py
+++ b/javatools/__init__.py
@@ -2128,7 +2128,7 @@ def _unpack_const_item(unpacker):
 
     elif typecode in (CONST_Fieldref, CONST_Methodref,
                       CONST_InterfaceMethodref, CONST_NameAndType,
-                      CONST_ModuleId, CONST_InvokeDynamic):
+                      CONST_ModuleId, CONST_InvokeDynamic, CONST_Dynamic):
         val = unpacker.unpack_struct(_HH)
 
     elif typecode == CONST_MethodHandle:

--- a/javatools/__init__.py
+++ b/javatools/__init__.py
@@ -49,7 +49,7 @@ __all__ = (
     "JavaCodeInfo", "JavaExceptionInfo", "JavaInnerClassInfo",
     "JavaAnnotation",
     "NoPoolException", "Unimplemented", "ClassUnpackException",
-    "UnknownConstantPoolTag", "UnpackException",
+    "UnknownConstantPoolTagException", "UnpackException",
     "platform_from_version",
     "is_class", "is_class_file",
     "unpack_class", "unpack_classfile",
@@ -161,7 +161,7 @@ class ClassUnpackException(Exception):
     pass
 
 
-class UnknownConstantPoolTag(Exception):
+class UnknownConstantPoolTagException(Exception):
     """
     raised when a constant pool tag is unknown and probably corrupted
     """
@@ -2147,7 +2147,7 @@ def _unpack_const_item(unpacker):
         val = unpacker.unpack_struct(_H)
 
     else:
-        raise UnknownConstantPoolTag("unknown constant type %r" % typecode)
+        raise UnknownConstantPoolTagException("unknown constant type %r" % typecode)
 
     return typecode, val
 

--- a/javatools/__init__.py
+++ b/javatools/__init__.py
@@ -260,7 +260,8 @@ class JavaConstantPool(object):
         #     u2 index; (valid index into the constant_pool)
         # }
         # NOTE: each constant can have a little bit different field name
-        elif t in (CONST_Class, CONST_String, CONST_MethodType, CONST_Module, CONST_Package):
+        elif t in (CONST_Class, CONST_String, CONST_MethodType,
+                   CONST_Module, CONST_Package):
             return self.deref_const(v)
 
         # CONSTANT_info {
@@ -276,8 +277,10 @@ class JavaConstantPool(object):
 
         # CONSTANT_info {
         #     u1 tag;
-        #     u2 bootstrap_method_attr_index; (must be a valid index into the bootstrap_methods array
-        #                                      of the bootstrap method table of this class file)
+        #     u2 bootstrap_method_attr_index; (must be a valid index into the
+        #                                      bootstrap_methods array
+        #                                      of the bootstrap method table of
+        #                                      this class file)
         #     u2 name_and_type_index; (valid index into the constant_pool)
         # }
         elif t in (CONST_InvokeDynamic, CONST_Dynamic):
@@ -294,7 +297,8 @@ class JavaConstantPool(object):
             return (v[0], self.deref_const(v[1]))
 
         else:
-            raise UnknownConstantPoolTagException("Unknown constant pool type %r" % t)
+            raise UnknownConstantPoolTagException(
+                "Unknown constant pool type %r" % t)
 
 
     def constants(self):
@@ -408,7 +412,8 @@ class JavaConstantPool(object):
             result = ""
 
         else:
-            raise UnknownConstantPoolTagException("No pretty for const type %r" % t)
+            raise UnknownConstantPoolTagException(
+                "No pretty for const type %r" % t)
 
         return result
 
@@ -2123,8 +2128,10 @@ def _unpack_const_item(unpacker):
             val = val.decode("utf8")
         except UnicodeDecodeError:
             # easiest hack to handle java's modified utf-8 encoding
-            # also we want at least some data, thus we ignore unknown characters
-            val = val.replace(b"\xC0\x80", b"\x00").decode("utf8", errors="ignore")
+            # also we want at least some data, thus we ignore
+            # unknown characters
+            val = val.replace(b"\xC0\x80", b"\x00") \
+                     .decode("utf8", errors="ignore")
 
     elif typecode == CONST_Integer:
         (val,) = unpacker.unpack(">i")
@@ -2154,7 +2161,8 @@ def _unpack_const_item(unpacker):
         val = unpacker.unpack_struct(_H)
 
     else:
-        raise UnknownConstantPoolTagException("unknown constant type %r" % typecode)
+        raise UnknownConstantPoolTagException(
+            "unknown constant type %r" % typecode)
 
     return typecode, val
 
@@ -2217,7 +2225,8 @@ def _pretty_const_type_val(typecode, val):
     elif typecode == CONST_Package:
         typestr = "Package"
     else:
-        raise UnknownConstantPoolTagException("unknown constant type %r" % typecode)
+        raise UnknownConstantPoolTagException(
+            "unknown constant type %r" % typecode)
 
     return typestr, val
 

--- a/javatools/__init__.py
+++ b/javatools/__init__.py
@@ -389,6 +389,13 @@ class JavaConstantPool(object):
             # TODO: v[0] needs to come from the bootstrap methods table
             result = "InvokeDynamic %r %r" % (v[0], self.deref_const(v[1]))
 
+        elif t == CONST_Dynamic:
+            # TODO: v[0] needs to come from the bootstrap methods table
+            result = "Dynamic %r %r" % (v[0], self.deref_const(v[1]))
+
+        elif t == CONST_MethodType:
+            result = "MethodType %r %r" % (v[0], self.deref_const(v[1]))
+
         elif t == CONST_Module:
             result = "Module %s" % self.deref_cons(v[0])
 

--- a/javatools/__init__.py
+++ b/javatools/__init__.py
@@ -255,13 +255,6 @@ class JavaConstantPool(object):
         elif t == CONST_MethodHandle:
             return (v[0], self.deref_const(v[1]))
 
-        elif t == CONST_MethodType:
-            return self.deref_const(v[0])
-
-        elif t == CONST_InvokeDynamic:
-            #TODO: v[0] is an index to an element in the bootstrap_methods array of the bootstrap method table
-            return self.deref_const(v[1])
-
         else:
             raise Unimplemented("Unknown constant pool type %r" % t)
 

--- a/javatools/__init__.py
+++ b/javatools/__init__.py
@@ -49,6 +49,7 @@ __all__ = (
     "JavaCodeInfo", "JavaExceptionInfo", "JavaInnerClassInfo",
     "JavaAnnotation",
     "NoPoolException", "Unimplemented", "ClassUnpackException",
+    "UnknownConstantPoolTag", "UnpackException",
     "platform_from_version",
     "is_class", "is_class_file",
     "unpack_class", "unpack_classfile",

--- a/javatools/manifest.py
+++ b/javatools/manifest.py
@@ -371,7 +371,8 @@ class Manifest(ManifestSection):
         :type data: bytes
         """
 
-        data = data.decode('utf-8')
+        # we want at least some data, thus we ignore unknown characters
+        data = data.decode('utf-8', errors="ignore")
         self.linesep = detect_linesep(data)
 
         # the first section is the main one for the manifest. It's


### PR DESCRIPTION
# This PR presents fixes to improve fail-proof ness

## Background
I am working with JAR files and I want to extract as much information as possible.
I've found javatools and wrote a python3 script based on it. The script parses the JAR file, its manifest, and all found class.
I've run this script on thousands of various JAR files and 1/7 of them ended up with some kind of 
exception. I've tried to fix them or at least catch them and this PR brings all fixes I made.

## Examples
If a JAR contains one corrupted class like [this one](https://github.com/obriencj/python-javatools/files/4381532/class_with_coruption.txt), the whole analysis fails (in this case on `get_requires`). I think that a better approach is to just skip this one class and continue.

If a JAR contains some file class (or manifest) with one unknown character like [this one](https://github.com/obriencj/python-javatools/files/4381543/class_with_unknown_characters.txt), the whole analysis fails (in this case `unpack_const_item`). I think that a better approach is to just skip this one character and continue.

## What this PR do:
- implements unimplemented Constant pool types `CONST_MethodHandle`, `CONST_MethodType`, `CONST_InvokeDynamic`, `CONST_Dynamic`
- ignore unknown characters during decoding
- fix implementation of `CONST_Module` and `CONST_Package`
- presents new exception `UnknownConstantPoolTagException` as a replace for a portion of `Unimplemented` exceptions

## Related issues (probably)
- [Java identifiers in .class files containing characters outside of BMP can fail to decode ](https://github.com/obriencj/python-javatools/issues/97)
- [RFE: Support for the CONSTANT_InvokeDynamic_info Structure](https://github.com/obriencj/python-javatools/issues/106)
- [Support for JDK 9 features](https://github.com/obriencj/python-javatools/issues/108)
- [Error running jarinfo with --jar-requires](https://github.com/obriencj/python-javatools/issues/109) 
This one would require probably catching `IndexError` while parsing `requires` or `provides`.
One class in this JAR might be corrupted and it would be better to skip it. I catch this exception in my script and I did not do it in javatools as I wanted to make as little "invasion" to javatools as possible.

## Notes
tests: `test_overriden_extension_handling` is failing on (your) master, other tests are successful

flake8: successful

Changes are based on https://docs.oracle.com/javase/specs/jvms/se14/jvms14.pdf 

## What to do after merge
- update `CHANGELOG`
- release new version (I would need it, so please)
