### PR TITLE
Raise an exception if an infinite loop occurs

### DIFF
--- a/javatools/__init__.py
+++ b/javatools/__init__.py
@@ -2294,6 +2294,19 @@ def _typeseq_iter(s):
         s = str(s)
         while s:
             t, s = _next_argsig(s)
+
+            # If `original == s` then it is possible that argument signature
+            # is corrupted which may lead to an infinite loop.
+            # In this case, raise an exception.
+            # Example:
+            # original = "LFR1Xdn"
+            # t, s = _next_argsig("LFR1Xdn"); original == s
+            if original == s and t == "":
+                raise Unimplemented(
+                    "Infinite loop detected: %r, %r = _next_argsig(%r)" %
+                    (t, s, original)
+                )
+
             yield t
 
     except Unimplemented:


### PR DESCRIPTION
## Background
I have found just one more issue since the last [PR](https://github.com/obriencj/python-javatools/pull/113).

## Topic
Corrupted argument signature may lead to an infinite loop.
Raise an `Unimplemented` exception to avoid it.

An [example](https://github.com/obriencj/python-javatools/files/4655117/example.zip) of such a class file.

## Notes
tests: `test_overriden_extension_handling` is still failing, other tests are successful

flake8: successful except some files I didn't even touch.

## What to do after merge
- (maybe) update `CHANGELOG`
- release a new version (I would like to use it)
