### PR TITLE
Improve detection of infinite loop in  _typeseq_iter() function

### DIFF
--- a/javatools/__init__.py
+++ b/javatools/__init__.py
@@ -2293,18 +2293,19 @@ def _typeseq_iter(s):
     try:
         s = str(s)
         while s:
+            old_s = s
             t, s = _next_argsig(s)
 
-            # If `original == s` then it is possible that argument signature
+            # If `old_s == s` then it is possible that argument signature
             # is corrupted which may lead to an infinite loop.
             # In this case, raise an exception.
             # Example:
-            # original = "LFR1Xdn"
-            # t, s = _next_argsig("LFR1Xdn"); original == s
-            if original == s and t == "":
+            # old_s = "LFR1Xdn"
+            # t, s = _next_argsig("LFR1Xdn"); old_s == s
+            if old_s == s and t == "":
                 raise Unimplemented(
                     "Infinite loop detected: %r, %r = _next_argsig(%r)" %
-                    (t, s, original)
+                    (t, s, old_s)
                 )
 
             yield t


### PR DESCRIPTION
## Background
Improve infinite loop detection presented in the older [PR](https://github.com/obriencj/python-javatools/pull/114).

## Topic
In the case, _next_argsig() does not change/divide the given string (output is the same as input), raise an error (infinite loop detected). The previous implementation tested the original value passed as a parameter to _typeseq_iter().
