### PR TITLE
Getting the first element of tuple before interact with it

### DIFF
--- a/javatools/__init__.py
+++ b/javatools/__init__.py
@@ -979,7 +979,7 @@ class JavaClassInfo(object):
                     # the event that this was a method or field on the
                     # array, we'll throw away that as well, and just
                     # emit the type contained in the array.
-                    t = _typeseq(pv)
+                    t = _typeseq(pv)[0]
                     if t[1] == "L":
                         pv = _pretty_type(t[1:])
                     else:


### PR DESCRIPTION
https://github.com/obriencj/python-javatools/blob/84339db1e05a498da2d06160074079e2bcc5283d/javatools/__init__.py#L2317-L2322

In this line 't' is a tuple like `('[C',)` or `('[Ljava.lang.Object;',)`:
https://github.com/obriencj/python-javatools/blob/84339db1e05a498da2d06160074079e2bcc5283d/javatools/__init__.py#L982

But in this line we really want to interact with the first element of that tuple:
https://github.com/obriencj/python-javatools/blob/84339db1e05a498da2d06160074079e2bcc5283d/javatools/__init__.py#L983