### PR TITLE
Fixed invalid sentinel for file iter

### DIFF
--- a/javatools/ziputils.py
+++ b/javatools/ziputils.py
@@ -219,7 +219,7 @@ def file_crc32(filename, chunksize=_CHUNKSIZE):
 
     check = 0
     with open(filename, 'rb') as fd:
-        for data in iter(lambda: fd.read(chunksize), ""):
+        for data in iter(lambda: fd.read(chunksize), b""):
             check = crc32(data, check)
     return check
 


### PR DESCRIPTION
In python3 file.read returns bytes and not string. This makes sentinel check to always fail leading to infinite loop on file read while computing crc32.
Using expected sentinel fixes it