### PR TITLE
Make M2Crypto an optional dependency

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,11 +1,18 @@
+Sun Jul 02 2023 Christopher O'Brien <obriencj@gmail.com> - 1.6.0
+	M2Crypto becomes an optional dependency. The crypto module adds a
+	new `crypto_enabled` function to check this, and a
+	`CryptoDisabled` exception for API calls which are invoked when
+	M2Crypto isn't available.
 
-Sun Jun 21 2020 Christopher O'Brien <obriencj@gmail.com> - 1.5.0-0
+	moves to tox for unittesting, flake8, and bandit integration
+
+Sun Jun 21 2020 Christopher O'Brien <obriencj@gmail.com> - 1.5.0
 	UnknownConstantPoolTagException
 
 	Updates to MethodHandle, MethodType, Dynamic, InvokeDynamic
 	(thanks Matus Jasnicky)
 
-Sun Oct 05 2019 Christopher O'Brien <obriencj@gmail.com> - 1.4.0-0
+Sun Oct 05 2019 Christopher O'Brien <obriencj@gmail.com> - 1.4.0
 	Python 3 support (thanks Konstantin Shemyak)
 
 	Moved to Cheetah3
@@ -38,7 +45,7 @@ Sun Oct 05 2019 Christopher O'Brien <obriencj@gmail.com> - 1.4.0-0
 
 	bugfixes
 
-Thu May 23 2013 Christopher O'Brien <obriencj@gmail.com> - 1.3-1
+Thu May 23 2013 Christopher O'Brien <obriencj@gmail.com> - 1.3
 	I think we've sat on these changes long enough, let's make a
 	release
 
@@ -58,7 +65,7 @@ Thu May 23 2013 Christopher O'Brien <obriencj@gmail.com> - 1.3-1
 
 	keep pylint happy
 
-Thu Jun 14 2012 Christopher O'Brien <obriencj@gmail.com> - 1.2-1
+Thu Jun 14 2012 Christopher O'Brien <obriencj@gmail.com> - 1.2
 	require python 2.6 and later rather than trying to fight with
 	library alternatives
 
@@ -76,8 +83,8 @@ Thu Jun 14 2012 Christopher O'Brien <obriencj@gmail.com> - 1.2-1
 	the html output is currently simplified, and will be expanded upon
 	later
 
-Sun May 6 2012 Christopher O'Brien <obriencj@gmail.com> - 1.1-1
+Sun May 6 2012 Christopher O'Brien <obriencj@gmail.com> - 1.1
 	dependency features, license files
 
-Fri Apr 27 2012 Christopher O'Brien <obriencj@gmail.com> - 1.0-1
+Fri Apr 27 2012 Christopher O'Brien <obriencj@gmail.com> - 1.0
 	Initial build.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,6 @@
 
 # Overview of python-javatools
 
-[![Build Status](https://travis-ci.org/obriencj/python-javatools.svg?branch=master)](https://travis-ci.org/obriencj/python-javatools)
-
-
 A [python] module for unpacking and inspecting [Java] Class files,
 JARs, and collections of either. Supporting features up to JDK 8.
 
@@ -27,21 +24,30 @@ heck, just fork it!
 
 ## Requirements
 
-* [Python] 2.7, 3.5, 3.6, 3.7
+* [Python] 2.7, 3.7, 3.8, 3.9, 3.10, 3.11
 * [Setuptools]
 * [Six]
 * [Cheetah3] is used in the generation of HTML reports
-* [M2Crypto] is used for cryptographic operations
+* [M2Crypto] (optional) is used for cryptographic operations
 
 In addition, the following tools are used in building and testing the
 project.
 
+* [Tox]
 * [GNU Make]
 * [Flake8]
 
 All of these packages are available in most linux distributions
-(eg. Fedora), and for OSX via [MacPorts], or available directly from
-pip.
+(eg. Fedora), and for OSX via [MacPorts] and [HomeBrew], or available
+directly from pip.
+
+M2Crypto can be difficult on some platforms, and so is set as an
+optional dependency. If an execution path attempts to perform an
+action which requires M2Crypto (primarily Jar signing and Jar
+signature verification), then a `CryptoDisabled` exception will be
+raised, or a message will be printed to stdout explaining that the
+feature is unavailable. See the [M2Crypto Install Guide] for
+workarounds in your environment.
 
 [six]: https://pypi.org/project/six/
 [cheetah3]: http://www.cheetahtemplate.org
@@ -51,9 +57,13 @@ pip.
 [setuptools]: https://pypi.org/project/setuptools/
 [gnu make]: http://www.gnu.org/software/make/
 [flake8]: https://pypi.org/project/flake8/
+[tox]: https://pypi.org/project/tox
 
-[fedora]: http://fedoraproject.org/
+[fedora]: http://fedoraproject.org
 [macports]: http://www.macports.org
+[homebrew]: https://brew.sh/
+
+[M2Crypto Install Guide]: https://gitlab.com/m2crypto/m2crypto/-/blob/master/INSTALL.rst
 
 
 ## Building
@@ -65,7 +75,7 @@ project:
 
 to install, run:
 
-```sudo python setup.py install```
+```python -m pip install . --user```
 
 
 ### Testing
@@ -74,6 +84,8 @@ Tests are written as `unittest` test cases. If you'd like to run the tests,
 simply invoke:
 
 ```python setup.py test```
+
+or invoke tests across a wider range of platforms via ``tox``
 
 
 ### RPM

--- a/javatools/jarutil.py
+++ b/javatools/jarutil.py
@@ -33,9 +33,11 @@ from shutil import copyfile
 from tempfile import NamedTemporaryFile
 from zipfile import ZipFile, ZIP_DEFLATED
 
+from .crypto import (
+    CryptoDisabled, CannotFindKeyTypeError, SignatureBlockVerificationError,
+    private_key_type, verify_signature_block,
+)
 from .manifest import file_matches_sigfile, Manifest, SignatureManifest
-from .crypto import private_key_type, CannotFindKeyTypeError
-from .crypto import verify_signature_block, SignatureBlockVerificationError
 
 
 __all__ = (
@@ -297,6 +299,10 @@ def cli_sign_jar(argument_list=None):
         sign(args.jar_file, args.cert_file, args.key_file, args.key_alias,
              args.extra_certs, args.digest, args.output)
 
+    except CryptoDisabled:
+        print("Signing jars requires M2Crypto")
+        return -1
+
     except CannotFindKeyTypeError:
         print("Cannot determine private key type in %s" % args.key_file)
         return 1
@@ -322,6 +328,10 @@ def cli_verify_jar_signature(argument_list):
     jar_file, certificate, sf_name = (argument_list + [None])[:3]
     try:
         verify(certificate, jar_file, sf_name)
+
+    except CryptoDisabled:
+        print("Verification of jar signatures requires M2Crypto")
+        return -1
 
     except VerificationError as error_message:
         print(error_message)

--- a/javatools/manifest.py
+++ b/javatools/manifest.py
@@ -543,6 +543,7 @@ class SignatureManifest(Manifest):
 
         self[all_key] = b64_encoded_digest(accum, digest)
 
+
     def verify_manifest_main_checksum(self, manifest):
         """
         Verify the checksum over the manifest main section.

--- a/python-javatools.spec
+++ b/python-javatools.spec
@@ -1,17 +1,13 @@
 Summary: Tools for inspecting and comparing binary Java class files
 Name: python-javatools
-Version: 1.5.0
-Release: 1
+Version: 1.6.0
+Release: 0
 License: LGPL
 Group: Application/System
 URL: https://github.com/obriencj/python-javatools/
 Source0: %{name}-%{version}.tar.gz
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 BuildArch: noarch
-
-# Don't believe we can do this, as there really was a "javaclass"
-# module already, and we do not want to Obsolete it by accident
-#Obsoletes: python-javaclass
 
 Requires: python2 >= 2.7
 Requires: python-cheetah
@@ -53,6 +49,9 @@ rm -rf %{buildroot}
 
 
 %changelog
+
+* Sun Jul 2 2023 Christopher O'Brien <obriencj@gmail.com> - 1.6.0-0
+- version 1.6.0
 
 * Sun Jun 21 2020 Christopher O'Brien <obriencj@gmail.com> - 1.5.0-1
 - version 1.5.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,13 +54,18 @@ setup_requires =
 
 install_requires =
   Cheetah3
-  M2Crypto >= 0.26.0
   six
 
 tests_require =
   Cheetah3
   M2Crypto >= 0.26.0
+  coverage
   six
+
+
+[options.extras_require]
+crypto =
+  M2Crypto >= 0.26.0
 
 
 [options.package_data]
@@ -104,22 +109,28 @@ setenv =
   COVERAGE_FILE = .coverage.{envname}
 
 commands =
-  coverage run -m nose
+  python -B -m coverage run -m nose
 
-sitepackages = false
-
-deps =
-  coverage
-  nose-py3
+sitepackages = true
 
 download = true
+
+deps =
+  Cheetah3
+  M2Crypto>=0.26.0
+  coverage
+  nose-py3
+  six
 
 
 [testenv:py27]
 
 deps =
+  Cheetah3
+  M2Crypto>=0.26.0
   coverage
   nose
+  six
 
 
 [testenv:bandit]
@@ -153,9 +164,9 @@ setenv =
 basepython = python
 
 commands =
-  coverage combine
-  coverage report
-  coverage html
+  python -B -m coverage combine
+  python -B -m coverage report
+  python -B -m coverage html
 
 
 [nosetests]

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@
 
 [metadata]
 name = javatools
-version = 1.5.1
+version = 1.6.0
 description = Tools for working with Java class files and JARs
 
 author = Christopher O'Brien


### PR DESCRIPTION
Converts M2Crypto into an optional dependency. Adds a new CryptoDisabled exception which is raised by API calls reaching a function which depends on M2Crypto. 