### PR TITLE
Prep v1.6.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,28 +81,4 @@ jobs:
       uses: pypa/gh-action-pypi-publish@release/v1
 
 
-  announce:
-    name: Announce release to @obriencj@fosstodon.org
-    runs-on: ubuntu-latest
-
-    needs:
-      - publish
-
-    steps:
-      - name: Get current date
-        id: date
-        run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
-
-      - name: Create announcement post
-        uses: rzr/fediverse-action@master
-        with:
-          host: fosstodon.org
-          access-token: ${{ secrets.MASTODON_ACCESS_TOKEN }}
-
-          message: |
-            Version ${{ github.ref }} of python-javatools was released on ${{ steps.date.outputs.date }}
-            https://github.com/obriencj/python-javatools/releases/tag/${{ github.ref }}
-            \#python \#javatools
-
-
 # The end.

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -14,16 +14,18 @@ on:
     ignore-paths:
       - 'docs/**'
     paths:
-      - '*.py'
-      - '*.tmpl'
+      - 'setup.*'
+      - '**/*.py'
+      - '**/*.tmpl'
       - 'tests/**'
 
   pull_request:
     ignore-paths:
       - 'docs/**'
     paths:
-      - '*.py'
-      - '*.tmpl'
+      - 'setup.*'
+      - '**/*.py'
+      - '**/*.tmpl'
       - 'tests/**'
 
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "gh-pages"]
+	path = gh-pages
+	url = ./
+	branch = gh-pages

--- a/Makefile
+++ b/Makefile
@@ -58,16 +58,6 @@ clean: clean-built tidy	## Removes built content, test logs, coverage reports
 	@rm -rf .coverage* htmlcov/* logs/*
 
 
-##@ Containerized RPMs
-packaging-build: $(ARCHIVE)	## Launches all containerized builds
-	@./tools/launch-build.sh
-
-
-packaging-test: packaging-build	## Launches all containerized tests
-	@rm -rf logs/*
-	@./tools/launch-test.sh
-
-
 ##@ Testing
 test: clean	## Launches tox
 	@tox
@@ -154,7 +144,7 @@ clean-docs:	## Remove built docs
 	@rm -rf build/sphinx/*
 
 
-.PHONY: archive build clean clean-built clean-docs default deploy-docs docs flake8 help mypy overview packaging-build packaging-test quick-test rpm srpm stage-docs test tidy
+.PHONY: archive build clean clean-built clean-docs default deploy-docs docs flake8 help mypy overview quick-test rpm srpm stage-docs test tidy
 
 
 # The end.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,160 @@
+# Sorry that this Makefile is a bit of a disaster.
+
+
+PYTHON ?= $(shell which python3 python 2>/dev/null | head -n1)
+PYTHON := $(PYTHON)
+
+
+PROJECT := $(shell $(PYTHON) ./setup.py --name)
+VERSION := $(shell $(PYTHON) ./setup.py --version)
+
+ARCHIVE := python-$(PROJECT)-$(VERSION).tar.gz
+
+
+# We use this later in setting up the gh-pages submodule for pushing,
+# so forks will push their docs to their own gh-pages branch.
+ORIGIN_PUSH = $(shell git remote get-url --push origin)
+
+
+##@ Basic Targets
+default: quick-test	## Runs the quick-test target
+
+
+help:  ## Display this help
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m\033[0m\n"} /^[a-zA-Z0-9_-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+
+
+report-python:
+	@echo "Using python" $(PYTHON)
+	@$(PYTHON) -VV
+
+
+##@ Local Build and Install
+build: clean-built report-python flake8	## Produces a wheel using the default system python
+	@$(PYTHON) setup.py bdist_wheel
+
+
+install: quick-test	## Installs using the default python for the current user
+	@$(PYTHON) -B -m pip.__main__ \
+		install --no-deps --user -I \
+		dist/$(PROJECT)-$(VERSION)-py3-none-any.whl
+
+
+##@ Cleanup
+tidy:	## Removes stray eggs and .pyc files
+	@rm -rf *.egg-info
+	@find -H . \
+		\( -iname '.tox' -o -iname '.eggs' -prune \) -o \
+		\( -type d -iname '__pycache__' -exec rm -rf {} + \) -o \
+		\( -type f -iname '*.pyc' -exec rm -f {} + \)
+
+
+clean-built:
+	@rm -rf build/* dist/*
+	@if [ -f ./"$(ARCHIVE)" ] ; then rm -f ./"$(ARCHIVE)" ; fi
+
+
+clean: clean-built tidy	## Removes built content, test logs, coverage reports
+	@rm -rf .coverage* htmlcov/* logs/*
+
+
+##@ Containerized RPMs
+packaging-build: $(ARCHIVE)	## Launches all containerized builds
+	@./tools/launch-build.sh
+
+
+packaging-test: packaging-build	## Launches all containerized tests
+	@rm -rf logs/*
+	@./tools/launch-test.sh
+
+
+##@ Testing
+test: clean	## Launches tox
+	@tox
+
+
+bandit: ## Launches bandit via tox
+	@tox -e bandit
+
+
+flake8:	## Launches flake8 via tox
+	@tox -e flake8
+
+
+mypy:	## Launches mypy via tox
+	@tox -e mypy
+
+
+quick-test: build	## Launches nosetest using the default python
+	@$(PYTHON) -B setup.py test $(NOSEARGS)
+
+
+##@ RPMs
+srpm: $(ARCHIVE)	## Produce an SRPM from the archive
+	@rpmbuild \
+		--define "_srcrpmdir dist" \
+		--define "dist %{nil}" \
+		-ts "$(ARCHIVE)"
+
+
+rpm: $(ARCHIVE)		## Produce an RPM from the archive
+	@rpmbuild --define "_rpmdir dist" -tb "$(ARCHIVE)"
+
+
+archive: $(ARCHIVE)	## Extracts an archive from the current git commit
+
+
+# newer versions support the --format tar.gz but we're intending to work all
+# the way back to RHEL 6 which does not have that.
+$(ARCHIVE):
+	@git archive HEAD \
+		--format tar --prefix "python-$(PROJECT)-$(VERSION)/" \
+		| gzip > "$(ARCHIVE)"
+
+
+##@ Documentation
+docs: clean-docs docs/overview.rst	## Build sphinx docs
+	@tox -e sphinx
+
+
+overview: docs/overview.rst  ## rebuilds the overview from README.md
+
+
+docs/overview.rst: README.md
+	@sed 's/^\[\!.*/ /g' $< > overview.md && \
+	pandoc --from=markdown --to=rst -o $@ "overview.md" && \
+	rm -f overview.md
+
+
+pull-docs:	## Refreshes the gh-pages submodule
+	@git submodule init
+	@git submodule update --remote gh-pages
+
+
+stage-docs: docs pull-docs	## Builds docs and stages them in gh-pages
+	@pushd gh-pages >/dev/null && \
+	rm -rf * && \
+	touch .nojekyll ; \
+	popd >/dev/null ; \
+	cp -vr build/sphinx/dirhtml/* gh-pages/
+
+
+deploy-docs: stage-docs	## Builds, stages, and deploys docs to gh-pages
+	@pushd gh-pages >/dev/null && \
+	git remote set-url --push origin $(ORIGIN_PUSH) ; \
+	git add -A && git commit -m "deploying sphinx update" && git push ; \
+	popd >/dev/null ; \
+	if [ `git diff --name-only gh-pages` ] ; then \
+		git add gh-pages ; \
+		git commit -m "docs deploy [ci skip]" -o gh-pages ; \
+	fi
+
+
+clean-docs:	## Remove built docs
+	@rm -rf build/sphinx/*
+
+
+.PHONY: archive build clean clean-built clean-docs default deploy-docs docs flake8 help mypy overview packaging-build packaging-test quick-test rpm srpm stage-docs test tidy
+
+
+# The end.

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -3,7 +3,7 @@ Overview of python-javatools
 
 A `python <http://python.org>`__ module for unpacking and inspecting
 `Java <http://www.oracle.com/technetwork/java/index.html>`__ Class
-files, JARs, and collections of either.
+files, JARs, and collections of either. Supporting features up to JDK 8.
 
 It can do deep checking of classes to perform comparisons of
 functionality, and output reports in multiple formats.
@@ -19,48 +19,60 @@ github. Or heck, just fork it!
 Requirements
 ------------
 
--  `Python <http://python.org>`__ 2.6 or later (no support for Python 3)
--  `Setuptools <http://pythonhosted.org/setuptools/>`__
--  `Cheetah <http://www.cheetahtemplate.org>`__ is used in the
+-  `Python <http://python.org>`__ 2.7, 3.7, 3.8, 3.9, 3.10, 3.11
+-  `Setuptools <https://pypi.org/project/setuptools/>`__
+-  `Six <https://pypi.org/project/six/>`__
+-  `Cheetah3 <http://www.cheetahtemplate.org>`__ is used in the
    generation of HTML reports
+-  `M2Crypto <https://gitlab.com/m2crypto/m2crypto/>`__ (optional) is
+   used for cryptographic operations
 
 In addition, the following tools are used in building and testing the
 project.
 
+-  `Tox <https://pypi.org/project/tox>`__
 -  `GNU Make <http://www.gnu.org/software/make/>`__
--  `Pylint <http://pypi.python.org/pypi/pylint/>`__
+-  `Flake8 <https://pypi.org/project/flake8/>`__
 
 All of these packages are available in most linux distributions (eg.
-Fedora), and for OSX via `MacPorts <http://www.macports.org>`__.
+Fedora), and for OSX via `MacPorts <http://www.macports.org>`__ and
+`HomeBrew <https://brew.sh/>`__, or available directly from pip.
+
+M2Crypto can be difficult on some platforms, and so is set as an
+optional dependency. If an execution path attempts to perform an action
+which requires M2Crypto (primarily Jar signing and Jar signature
+verification), then a ``CryptoDisabled`` exception will be raised, or a
+message will be printed to stdout explaining that the feature is
+unavailable. See the `M2Crypto Install
+Guide <https://gitlab.com/m2crypto/m2crypto/-/blob/master/INSTALL.rst>`__
+for workarounds in your environment.
 
 Building
 --------
 
-This module uses `setuptools <http://pythonhosted.org/setuptools/>`__,
+This module uses `setuptools <https://pypi.org/project/setuptools/>`__,
 so running the following will build the project:
 
 ``python setup.py build``
 
 to install, run:
 
-``sudo python setup.py install``
+``python -m pip install . --user``
 
 Testing
 ~~~~~~~
 
-Tests are written as ``unittest`` test cases. If you'd like to run the
+Tests are written as ``unittest`` test cases. If you’d like to run the
 tests, simply invoke:
 
 ``python setup.py test``
 
-There is also a custom ``pylint`` command, which can be use via:
-
-``python setup.py pylint``
+or invoke tests across a wider range of platforms via ``tox``
 
 RPM
 ~~~
 
-If you'd prefer to build an RPM, see the wiki entry for `Building as an
+If you’d prefer to build an RPM, see the wiki entry for `Building as an
 RPM <https://github.com/obriencj/python-javatools/wiki/Building-as-an-RPM>`__.
 
 Javatools Scripts
@@ -77,7 +89,9 @@ Javatools Scripts
 -  jardiff - prints the deltas between the contents of a JAR, and runs
    classdiff on differing Java class files contained in the JARs
 
--  manifest - creates manifests, signs JAR with OpenSSL
+-  jarutil - creates and signs JARs, verifies JAR signatures
+
+-  manifest - creates and queries JAR manifests
 
 -  distinfo - prints information about a mixed multi-jar/class
    distribution, such as provides/requires lists.
@@ -88,19 +102,21 @@ Javatools Scripts
 Additional References
 ---------------------
 
--  Oracle's Java Virtual Machine Specification `Chapter 4 "The class
+-  Oracle’s Java Virtual Machine Specification `Chapter 4 “The class
    File
-   Format" <http://docs.oracle.com/javase/specs/jvms/se7/html/jvms-4.html>`__
+   Format” <http://docs.oracle.com/javase/specs/jvms/se7/html/jvms-4.html>`__
 -  `Java Archive (JAR)
    Files <http://docs.oracle.com/javase/1.5.0/docs/guide/jar/index.html>`__
 
 Contact
 -------
 
-Christopher O'Brien obriencj@gmail.com
+Author: Christopher O’Brien obriencj@gmail.com
 
-If you're interested in my other projects, feel free to visit `my
+If you’re interested in my other projects, feel free to visit `my
 blog <http://obriencj.preoccupied.net/>`__.
+
+Original Git Repository: https://github.com/obriencj/python-javatools
 
 License
 -------

--- a/python-javatools.spec
+++ b/python-javatools.spec
@@ -168,14 +168,15 @@ Python Java Tools
 
 %changelog
 
-* Sun Jul 2 2023 Christopher O'Brien <obriencj@gmail.com> - 1.6.0-0
+* Thu Jul 27 2023 Christopher O'Brien <obriencj@gmail.com> - 1.6.0-1
 - version 1.6.0
 - m2crypto is runtime optional
+- python2 and python3 support
 
 * Sun Jun 21 2020 Christopher O'Brien <obriencj@gmail.com> - 1.5.0-1
 - version 1.5.0
 
-* Thu Jan 21 2014 Christopher O'Brien <obriencj@gmail.com> - 1.4.0-1
+* Sun Oct 05 2019 Christopher O'Brien <obriencj@gmail.com> - 1.4.0-1
 - version 1.4.0
 - added ChangeLog as its own file
 - move to setuptools
@@ -186,7 +187,7 @@ Python Java Tools
 * Thu Jun 14 2012 Christopher O'Brien <obriencj@gmail.com> - 1.2-1
 - require python 2.6 and later
 
-* Sun May 6 2012 Christopher O'Brien <obriencj@gmail.com> - 1.1-1
+* Sun May 06 2012 Christopher O'Brien <obriencj@gmail.com> - 1.1-1
 - dependency features, license files
 
 * Fri Apr 27 2012 Christopher O'Brien <obriencj@gmail.com> - 1.0-1

--- a/python-javatools.spec
+++ b/python-javatools.spec
@@ -1,7 +1,7 @@
 %global srcproj javatools
 %global srcname python-%{srcproj}
 %global srcver 1.6.0
-%global srcrel 0
+%global srcrel 1
 
 
 # There's two distinct eras of RPM packaging for python, with

--- a/python-javatools.spec
+++ b/python-javatools.spec
@@ -1,22 +1,44 @@
+%global srcproj javatools
+%global srcname python-%{srcproj}
+%global srcver 1.6.0
+%global srcrel 0
+
+
+# There's two distinct eras of RPM packaging for python, with
+# different macros and different expectations. Generally speaking the
+# new features are available in RHEL 8+ and Fedora 22+
+
+%define old_rhel ( 0%{?rhel} && 0%{?rhel} < 8 )
+%define old_fedora ( 0%{?fedora} && 0%{?fedora} < 22 )
+
+%if %{old_rhel} || %{old_fedora}
+  # old python 2.6 support
+  %define with_old_python 1
+  %undefine with_python2
+  %undefine with_python3
+%else
+  # newer pythons, with cooler macros
+  %undefine with_old_python
+  %bcond_with python2
+  %bcond_without python3
+%endif
+
+
+# we don't generate binaries, let's turn the debuginfo part off
+%global debug_package %{nil}
+
+
 Summary: Tools for inspecting and comparing binary Java class files
-Name: python-javatools
-Version: 1.6.0
-Release: 0
-License: LGPL
+Name: %{srcname}
+Version: %{srcver}
+Release: %{srcrel}%{?dist}
+License: LGPLv3
 Group: Application/System
 URL: https://github.com/obriencj/python-javatools/
-Source0: %{name}-%{version}.tar.gz
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 BuildArch: noarch
 
-Requires: python2 >= 2.7
-Requires: python-cheetah
-Requires: M2Crypto
-
-BuildRequires: python2-devel
-BuildRequires: python-cheetah
-BuildRequires: python-setuptools
-BuildRequires: coreutils
+Source0: %{srcname}-%{srcver}.tar.gz
 
 
 %description
@@ -29,29 +51,126 @@ JAR-based distributions
 
 
 %build
-%{__python2} setup.py build
+
+%if %{with old_python}
+  %{__python} setup.py build
+%endif
+
+%if %{with python2}
+  %py2_build_wheel
+%endif
+
+%if %{with python3}
+  %py3_build_wheel
+%endif
 
 
 %install
-rm -rf %{buildroot}
-%{__python2} setup.py install --skip-build --root %{buildroot}
+%__rm -rf $RPM_BUILD_ROOT
+
+%if %{with old_python}
+  %{__python} setup.py install --skip-build --root %{buildroot}
+%endif
+
+%if %{with python2}
+  %py2_install_wheel %{srcproj}-%{version}-py2-none-any.whl
+%endif
+
+%if %{with python3}
+  %py3_install_wheel %{srcproj}-%{version}-py3-none-any.whl
+%endif
 
 
 %clean
 rm -rf %{buildroot}
 
 
-%files
+%if %{with old_python}
+# package support for older python systems (centos 6, fedora
+# 19) with only python 2.6 available.
+
+%package -n python2-%{srcproj}
+Summary:        %{summary}
+BuildRequires:  python-devel python-setuptools
+BuildRequires:  python-cheetah python-six
+Requires:	python python-argparse python-setuptools
+Requires:       python-cheetah python-six
+%{?python_provide:%python_provide python2-%{srcproj}}
+
+%description -n python2-%{srcproj}
+Python Java Tools
+
+%files -n python2-%{srcproj}
 %defattr(-,root,root,-)
-%doc AUTHORS ChangeLog LICENSE README.md TODO
-%{python2_sitelib}/*
+%{python2_sitelib}/javatools/
+%{python2_sitelib}/javatools-%{version}.dist-info
 %{_bindir}/*
+
+%doc AUTHORS ChangeLog README.md
+%license LICENSE
+
+%endif
+
+
+%if %{with python2}
+
+%package -n python2-%{srcproj}
+Summary:        %{summary}
+BuildRequires:  python2-devel
+BuildRequires:  python2-pip python2-setuptools python2-wheel
+BuildRequires:  python2-cheetah python2-six
+Requires:	python2 python2-setuptools
+Requires:       python2-cheetah python2-six
+%{?python_provide:%python_provide python2-%{srcproj}}
+%{?py_provides:%py_provides python2-%{srcproj}}
+
+%description -n python2-%{srcproj}
+Python Java Tools
+
+%files -n python2-%{srcproj}
+%defattr(-,root,root,-)
+%{python2_sitelib}/javatools/
+%{python2_sitelib}/javatools-%{version}.dist-info
+%{_bindir}/*
+
+%doc AUTHORS ChangeLog README.md
+%license LICENSE
+
+%endif
+
+
+%if %{with python3}
+
+%package -n python3-%{srcproj}
+Summary:        %{summary}
+BuildRequires:  python3-devel
+BuildRequires:  python3-pip python3-setuptools python3-wheel
+BuildRequires:  python3-cheetah python3-six
+Requires:	python3 python3-setuptools
+Requires:       python3-cheetah python3-six
+%{?python_provide:%python_provide python3-%{srcproj}}
+%{?py_provides:%py_provides python3-%{srcproj}}
+
+%description -n python3-%{srcproj}
+Python Java Tools
+
+%files -n python3-%{srcproj}
+%defattr(-,root,root,-)
+%{python3_sitelib}/javatools/
+%{python3_sitelib}/javatools-%{version}.dist-info
+%{_bindir}/*
+
+%doc AUTHORS ChangeLog README.md
+%license LICENSE
+
+%endif
 
 
 %changelog
 
 * Sun Jul 2 2023 Christopher O'Brien <obriencj@gmail.com> - 1.6.0-0
 - version 1.6.0
+- m2crypto is runtime optional
 
 * Sun Jun 21 2020 Christopher O'Brien <obriencj@gmail.com> - 1.5.0-1
 - version 1.5.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -100,7 +100,7 @@ test = nosetests
 
 
 [tox:tox]
-envlist = flake8,py{27,37,38,39,310,311},coverage,bandit
+envlist = flake8,py{27,37,38,39,310,311},coverage,bandit,twine
 skip_missing_interpreters = true
 
 
@@ -142,6 +142,18 @@ commands =
 
 deps =
   bandit
+
+
+[testenv:twine]
+
+basepython = python3.9
+
+commands =
+  python -B setup.py bdist_wheel
+  python -B -m twine check --strict dist/*.whl
+
+deps =
+  twine
 
 
 [testenv:flake8]

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,8 @@ author = Christopher O'Brien
 author_email = obriencj@gmail.com
 
 license = GNU Lesser General Public License v3 (LGPLv3)
-license_file = LICENSE
+license_files =
+  LICENSE
 
 long_description = file: README.md
 long_description_content_type = text/markdown
@@ -222,6 +223,35 @@ exclude =
   tests
   todo
   tools
+
+
+[testenv:sphinx]
+
+basepython = python3.9
+
+commands =
+  python -B setup.py build_sphinx
+
+# sphinx 7 not only doesn't have a build_sphinx command, but it also
+# completely ignores the settings in setup.cfg
+deps =
+  sphinx<7
+  numpydoc
+
+
+[build_sphinx]
+# some of the configuration for sphinx. The rest of it lives over in
+# docs/conf.py
+
+version = 1.6
+release = 1.6.0
+
+project = python-javatools
+copyright = 2014-2023, Christopher O'Brien
+
+build-dir = build/sphinx
+builder = dirhtml html
+source-dir = docs
 
 
 [gh-actions]


### PR DESCRIPTION
Prepare for version 1.6.0 release

Update the spec file to support py2/py3 across various rhel-like systems. Add Makefile for easier management of tasks. Bump docs configs.

Relates to #129
Closes #130
